### PR TITLE
fix: removed the utf-8 encoding from the PostAsync fucntion

### DIFF
--- a/src/GraphQL.Client/GraphQLClient.cs
+++ b/src/GraphQL.Client/GraphQLClient.cs
@@ -177,9 +177,13 @@ namespace GraphQL.Client {
 			if (request.Query == null) { throw new ArgumentNullException(nameof(request.Query)); }
 
 			var graphQLString = JsonConvert.SerializeObject(request, this.Options.JsonSerializerSettings);
-			using (var httpContent = new StringContent(graphQLString, Encoding.UTF8, this.Options.MediaType.MediaType))
-			using (var httpResponseMessage = await this.httpClient.PostAsync(this.EndPoint, httpContent, cancellationToken).ConfigureAwait(false)) {
-				return await this.ReadHttpResponseMessageAsync(httpResponseMessage).ConfigureAwait(false);
+			using (var httpContent = new StringContent(graphQLString))
+			{
+				httpContent.Headers.ContentType = this.Options.MediaType;
+				using (var httpResponseMessage = await this.httpClient.PostAsync(this.EndPoint, httpContent, cancellationToken).ConfigureAwait(false))
+				{
+					return await this.ReadHttpResponseMessageAsync(httpResponseMessage).ConfigureAwait(false);
+				} 
 			}
 		}
 

--- a/src/GraphQL.Client/GraphQLClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLClientOptions.cs
@@ -31,7 +31,7 @@ namespace GraphQL.Client {
 		/// <summary>
 		/// The <see cref="MediaTypeHeaderValue"/> that will be send on POST
 		/// </summary>
-		public MediaTypeHeaderValue MediaType { get; set; } = new MediaTypeHeaderValue("application/json"); // This should be "application/graphql" also "application/x-www-form-urlencoded" is Accepted
+		public MediaTypeHeaderValue MediaType { get; set; } = MediaTypeHeaderValue.Parse("application/json; charset=utf-8"); // This should be "application/graphql" also "application/x-www-form-urlencoded" is Accepted
 
 	}
 

--- a/tests/GraphQL.Client.Tests/GraphQLClientPostTests.cs
+++ b/tests/GraphQL.Client.Tests/GraphQLClientPostTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using GraphQL.Common.Request;
 using GraphQL.Common.Tests.Model;
 using Xunit;
@@ -16,6 +17,25 @@ namespace GraphQL.Client.Tests {
 					}
 				}"
 			};
+			var response = await this.GraphQLClient.PostAsync(graphQLRequest).ConfigureAwait(false);
+
+			Assert.Equal("Luke Skywalker", response.Data.person.name.Value);
+			Assert.Equal("Luke Skywalker", response.GetDataFieldAs<Person>("person").Name);
+		}
+
+		[Fact]
+		public async void QueryPostAsyncWithoutUtf8EncodingFact()
+		{
+			var graphQLRequest = new GraphQLRequest
+			{
+				Query = @"
+				{
+					person(personID: ""1"") {
+						name
+					}
+				}"
+			};
+			this.GraphQLClient.Options.MediaType = MediaTypeHeaderValue.Parse("application/json");
 			var response = await this.GraphQLClient.PostAsync(graphQLRequest).ConfigureAwait(false);
 
 			Assert.Equal("Luke Skywalker", response.Data.person.name.Value);


### PR DESCRIPTION
Removed the utf-8 encoding from the StringContent parameter list and moved it to the MediaType value in  GraphQLClientOptions class. The reason to do this was the API which I'm connecting rejects the uft-8 encoding along with ContentType as 'application/json'. So to allow clients to customize the ContentType and not restrict them to use utf-8 encoding I have updated the GraphQLClientOptions.MediaType property's default value.

I have also added a new test that proves that ContentType without utf-8 encoding work along with all the existing tests. I would have added more test to assert the default media/content type contains utf-8 from the request but unfortunately the GraphQLClient doesn't expose the httpClient.

Please let me know if you have any queries or suggestions.