### PR TITLE
Remove forced camel casing

### DIFF
--- a/src/GraphQL.Client/Http/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/Http/GraphQLHttpClient.cs
@@ -100,26 +100,26 @@ namespace GraphQL.Client.Http {
 			this.graphQLHttpHandler = new GraphQLHttpHandler(options,httpClient);
 		}
 
-		public async Task<GraphQLResponse> SendQueryAsync(string query, CancellationToken cancellationToken = default) =>
-			await this.SendQueryAsync(new GraphQLRequest { Query = query }, cancellationToken).ConfigureAwait(false);
+		public async Task<GraphQLResponse> SendQueryAsync(string _query, CancellationToken cancellationToken = default) =>
+			await this.SendQueryAsync(new GraphQLRequest { query = _query }, cancellationToken).ConfigureAwait(false);
 
 		public async Task<GraphQLResponse> SendQueryAsync(GraphQLRequest request, CancellationToken cancellationToken = default) =>
 			await this.graphQLHttpHandler.PostAsync(request, cancellationToken).ConfigureAwait(false);
 
-		public async Task<GraphQLResponse> SendMutationAsync(string query, CancellationToken cancellationToken = default) =>
-			await this.SendMutationAsync(new GraphQLRequest { Query = query }, cancellationToken).ConfigureAwait(false);
+		public async Task<GraphQLResponse> SendMutationAsync(string _query, CancellationToken cancellationToken = default) =>
+			await this.SendMutationAsync(new GraphQLRequest { query = _query }, cancellationToken).ConfigureAwait(false);
 
 		public async Task<GraphQLResponse> SendMutationAsync(GraphQLRequest request, CancellationToken cancellationToken = default) =>
 			await this.graphQLHttpHandler.PostAsync(request, cancellationToken).ConfigureAwait(false);
 
 		[Obsolete("EXPERIMENTAL API")]
-		public async Task<IGraphQLSubscriptionResult> SendSubscribeAsync(string query, CancellationToken cancellationToken = default) =>
-			await this.SendSubscribeAsync(new GraphQLRequest { Query = query }, cancellationToken).ConfigureAwait(false);
+		public async Task<IGraphQLSubscriptionResult> SendSubscribeAsync(string _query, CancellationToken cancellationToken = default) =>
+			await this.SendSubscribeAsync(new GraphQLRequest { query = _query }, cancellationToken).ConfigureAwait(false);
 
 		[Obsolete("EXPERIMENTAL API")]
 		public async Task<IGraphQLSubscriptionResult> SendSubscribeAsync(GraphQLRequest request, CancellationToken cancellationToken = default) {
 			if (request == null) { throw new ArgumentNullException(nameof(request)); }
-			if (request.Query == null) { throw new ArgumentNullException(nameof(request.Query)); }
+			if (request.query == null) { throw new ArgumentNullException(nameof(request.query)); }
 
 			var webSocketUri = new Uri($"ws://{this.EndPoint.Host}:{this.EndPoint.Port}{this.EndPoint.AbsolutePath}");
 			var graphQLSubscriptionResult = new GraphQLHttpSubscriptionResult(webSocketUri, request);

--- a/src/GraphQL.Client/Http/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/Http/GraphQLHttpClientOptions.cs
@@ -20,7 +20,6 @@ namespace GraphQL.Client.Http {
 		/// The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> that is going to be used
 		/// </summary>
 		public JsonSerializerSettings JsonSerializerSettings { get; set; } = new JsonSerializerSettings {
-			ContractResolver = new CamelCasePropertyNamesContractResolver()
 		};
 
 		/// <summary>

--- a/src/GraphQL.Client/Http/Internal/GraphQLHttpHandler.cs
+++ b/src/GraphQL.Client/Http/Internal/GraphQLHttpHandler.cs
@@ -44,11 +44,11 @@ namespace GraphQL.Client.Http.Internal {
 		/// <returns>The Response</returns>
 		public async Task<GraphQLResponse> GetAsync(GraphQLRequest request, CancellationToken cancellationToken = default) {
 			if (request == null) { throw new ArgumentNullException(nameof(request)); }
-			if (request.Query == null) { throw new ArgumentNullException(nameof(request.Query)); }
+			if (request.query == null) { throw new ArgumentNullException(nameof(request.query)); }
 
-			var queryParamsBuilder = new StringBuilder($"query={request.Query}", 3);
-			if (request.OperationName != null) { queryParamsBuilder.Append($"&operationName={request.OperationName}"); }
-			if (request.Variables != null) { queryParamsBuilder.Append($"&variables={JsonConvert.SerializeObject(request.Variables)}"); }
+			var queryParamsBuilder = new StringBuilder($"query={request.query}", 3);
+			if (request.operationName != null) { queryParamsBuilder.Append($"&operationName={request.operationName}"); }
+			if (request.variables != null) { queryParamsBuilder.Append($"&variables={JsonConvert.SerializeObject(request.variables)}"); }
 			using (var httpResponseMessage = await this.HttpClient.GetAsync($"{this.Options.EndPoint}?{queryParamsBuilder.ToString()}", cancellationToken).ConfigureAwait(false)) {
 				return await this.ReadHttpResponseMessageAsync(httpResponseMessage).ConfigureAwait(false);
 			}
@@ -62,7 +62,7 @@ namespace GraphQL.Client.Http.Internal {
 		/// <returns>The Response</returns>
 		public async Task<GraphQLResponse> PostAsync(GraphQLRequest request, CancellationToken cancellationToken = default) {
 			if (request == null) { throw new ArgumentNullException(nameof(request)); }
-			if (request.Query == null) { throw new ArgumentNullException(nameof(request.Query)); }
+			if (request.query == null) { throw new ArgumentNullException(nameof(request.query)); }
 
 			var graphQLString = JsonConvert.SerializeObject(request, this.Options.JsonSerializerSettings);
 			using (var httpContent = new StringContent(graphQLString)) {

--- a/src/GraphQL.Client/Obsolete.GraphQLClient.Extensions.cs
+++ b/src/GraphQL.Client/Obsolete.GraphQLClient.Extensions.cs
@@ -100,8 +100,8 @@ namespace GraphQL.Client {
 				}";
 
 		private static readonly GraphQLRequest IntrospectionGraphQLRequest = new GraphQLRequest {
-			Query = IntrospectionQuery.Replace("\t", "").Replace("\n", "").Replace("\r", ""),
-			Variables = null
+			query = IntrospectionQuery.Replace("\t", "").Replace("\n", "").Replace("\r", ""),
+			variables = null
 		};
 
 		/// <summary>

--- a/src/GraphQL.Client/Obsolete.GraphQLClient.cs
+++ b/src/GraphQL.Client/Obsolete.GraphQLClient.cs
@@ -49,11 +49,11 @@ namespace GraphQL.Client {
 		/// <summary>
 		/// Send a query via GET
 		/// </summary>
-		/// <param name="query">The Request</param>
+		/// <param name="_query">The Request</param>
 		/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
 		/// <returns>The Response</returns>
-		public async Task<GraphQLResponse> GetQueryAsync(string query, CancellationToken cancellationToken = default) =>
-			await this.GetAsync(new GraphQLRequest { Query = query }, cancellationToken).ConfigureAwait(false);
+		public async Task<GraphQLResponse> GetQueryAsync(string _query, CancellationToken cancellationToken = default) =>
+			await this.GetAsync(new GraphQLRequest { query = _query }, cancellationToken).ConfigureAwait(false);
 
 		/// <summary>
 		/// Send a <see cref="GraphQLRequest"/> via GET
@@ -67,11 +67,11 @@ namespace GraphQL.Client {
 		/// <summary>
 		/// Send a query via POST
 		/// </summary>
-		/// <param name="query">The Request</param>
+		/// <param name="_query">The Request</param>
 		/// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
 		/// <returns>The Response</returns>
-		public async Task<GraphQLResponse> PostQueryAsync(string query, CancellationToken cancellationToken = default) =>
-			await this.PostAsync(new GraphQLRequest { Query = query }, cancellationToken).ConfigureAwait(false);
+		public async Task<GraphQLResponse> PostQueryAsync(string _query, CancellationToken cancellationToken = default) =>
+			await this.PostAsync(new GraphQLRequest { query = _query }, cancellationToken).ConfigureAwait(false);
 
 		/// <summary>
 		/// Send a <see cref="GraphQLRequest"/> via POST

--- a/src/GraphQL.Common/Request/GraphQLRequest.cs
+++ b/src/GraphQL.Common/Request/GraphQLRequest.cs
@@ -12,17 +12,17 @@ namespace GraphQL.Common.Request {
 		/// <summary>
 		/// The Query
 		/// </summary>
-		public string Query { get; set; }
+		public string query { get; set; }
 
 		/// <summary>
-		/// If the provided <see cref="Query"/> contains multiple named operations, this specifies which operation should be executed.
+		/// If the provided <see cref="query"/> contains multiple named operations, this specifies which operation should be executed.
 		/// </summary>
-		public string OperationName { get; set; }
+		public string operationName { get; set; }
 
 		/// <summary>
 		/// The Variables
 		/// </summary>
-		public dynamic Variables { get; set; }
+		public dynamic variables { get; set; }
 
 		/// <inheritdoc />
 		public override bool Equals(object obj) => this.Equals(obj as GraphQLRequest);
@@ -35,13 +35,13 @@ namespace GraphQL.Common.Request {
 			if (ReferenceEquals(this, other)) {
 				return true;
 			}
-			if (!Equals(this.Query, other.Query)) {
+			if (!Equals(this.query, other.query)) {
 				return false;
 			}
-			if (!Equals(this.OperationName, other.OperationName)) {
+			if (!Equals(this.operationName, other.operationName)) {
 				return false;
 			}
-			if (!Equals(this.Variables, other.Variables)) {
+			if (!Equals(this.variables, other.variables)) {
 				return false;
 			}
 			return true;
@@ -50,9 +50,9 @@ namespace GraphQL.Common.Request {
 		/// <inheritdoc />
 		public override int GetHashCode() {
 			var hashCode = -689803966;
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Query);
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.OperationName);
-			hashCode = hashCode * -1521134295 + EqualityComparer<dynamic>.Default.GetHashCode(this.Variables);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.query);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.operationName);
+			hashCode = hashCode * -1521134295 + EqualityComparer<dynamic>.Default.GetHashCode(this.variables);
 			return hashCode;
 		}
 

--- a/tests/GraphQL.Client.Tests/GraphQLClientGetTests.cs
+++ b/tests/GraphQL.Client.Tests/GraphQLClientGetTests.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void QueryGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				{
 					person(personID: ""1"") {
 						name
@@ -25,7 +25,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNameGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person{
 					person(personID: ""1"") {
 						name
@@ -37,7 +37,7 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person"
+				operationName = "Person"
 			};
 			var response = await this.GraphQLClient.GetAsync(graphQLRequest).ConfigureAwait(false);
 
@@ -48,13 +48,13 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void VariablesGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
 					}
 				}",
-				Variables = new {
+				variables = new {
 					personId = "1"
 				}
 			};
@@ -67,7 +67,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNameVariableGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
@@ -79,8 +79,8 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person",
-				Variables = new {
+				operationName = "Person",
+				variables = new {
 					personId = "1"
 				}
 			};

--- a/tests/GraphQL.Client.Tests/GraphQLClientPostTests.cs
+++ b/tests/GraphQL.Client.Tests/GraphQLClientPostTests.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void QueryPostAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				{
 					person(personID: ""1"") {
 						name
@@ -28,7 +28,7 @@ namespace GraphQL.Client.Tests {
 		{
 			var graphQLRequest = new GraphQLRequest
 			{
-				Query = @"
+				query = @"
 				{
 					person(personID: ""1"") {
 						name
@@ -45,7 +45,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNamePostAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person{
 					person(personID: ""1"") {
 						name
@@ -57,7 +57,7 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person"
+				operationName = "Person"
 			};
 			var response = await this.GraphQLClient.PostAsync(graphQLRequest).ConfigureAwait(false);
 
@@ -68,13 +68,13 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void VariablesPostAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
 					}
 				}",
-				Variables = new {
+				variables = new {
 					personId = "1"
 				}
 			};
@@ -87,7 +87,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNameVariablePostAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
@@ -99,8 +99,8 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person",
-				Variables = new {
+				operationName = "Person",
+				variables = new {
 					personId = "1"
 				}
 			};

--- a/tests/GraphQL.Client.Tests/Http/HttpClientExtensionsTest.cs
+++ b/tests/GraphQL.Client.Tests/Http/HttpClientExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Client.Tests.Http {
 		[Fact]
 		public async void QueryGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				{
 					person(personID: ""1"") {
 						name
@@ -30,7 +30,7 @@ namespace GraphQL.Client.Tests.Http {
 		[Fact]
 		public async void OperationNameGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person{
 					person(personID: ""1"") {
 						name
@@ -42,7 +42,7 @@ namespace GraphQL.Client.Tests.Http {
 						name
 					}
 				}",
-				OperationName = "Person"
+				operationName = "Person"
 			};
 			var response = await this.GraphQLHttpClient.SendQueryAsync(graphQLRequest).ConfigureAwait(false);
 
@@ -53,13 +53,13 @@ namespace GraphQL.Client.Tests.Http {
 		[Fact]
 		public async void VariablesGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
 					}
 				}",
-				Variables = new {
+				variables = new {
 					personId = "1"
 				}
 			};
@@ -72,7 +72,7 @@ namespace GraphQL.Client.Tests.Http {
 		[Fact]
 		public async void OperationNameVariableGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
@@ -84,8 +84,8 @@ namespace GraphQL.Client.Tests.Http {
 						name
 					}
 				}",
-				OperationName = "Person",
-				Variables = new {
+				operationName = "Person",
+				variables = new {
 					personId = "1"
 				}
 			};

--- a/tests/GraphQL.Client.Tests/IGraphQLClientTest.cs
+++ b/tests/GraphQL.Client.Tests/IGraphQLClientTest.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void QueryGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				{
 					person(personID: ""1"") {
 						name
@@ -25,7 +25,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNameGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person{
 					person(personID: ""1"") {
 						name
@@ -37,7 +37,7 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person"
+				operationName = "Person"
 			};
 			var response = await this.GraphQLClientSwapi.SendQueryAsync(graphQLRequest).ConfigureAwait(false);
 
@@ -48,13 +48,13 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void VariablesGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
 					}
 				}",
-				Variables = new {
+				variables = new {
 					personId = "1"
 				}
 			};
@@ -67,7 +67,7 @@ namespace GraphQL.Client.Tests {
 		[Fact]
 		public async void OperationNameVariableGetAsyncFact() {
 			var graphQLRequest = new GraphQLRequest {
-				Query = @"
+				query = @"
 				query Person($personId: ID!){
 					person(personID: $personId) {
 						name
@@ -79,8 +79,8 @@ namespace GraphQL.Client.Tests {
 						name
 					}
 				}",
-				OperationName = "Person",
-				Variables = new {
+				operationName = "Person",
+				variables = new {
 					personId = "1"
 				}
 			};

--- a/tests/GraphQL.Common.Tests/AssertGraphQL.cs
+++ b/tests/GraphQL.Common.Tests/AssertGraphQL.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Common.Tests {
 
 	public static class AssertGraphQL {
 
-		public static void CorrectGraphQLRequest(GraphQLRequest graphQLRequest) => Assert.NotNull(graphQLRequest.Query);
+		public static void CorrectGraphQLRequest(GraphQLRequest graphQLRequest) => Assert.NotNull(graphQLRequest.query);
 
 		public static void CorrectGraphQLResponse(GraphQLResponse graphQLResponse) {
 			Assert.NotNull(graphQLResponse.Data);

--- a/tests/GraphQL.Common.Tests/Request/GraphQLRequestConsts.cs
+++ b/tests/GraphQL.Common.Tests/Request/GraphQLRequestConsts.cs
@@ -8,20 +8,20 @@ namespace GraphQL.Common.Tests.Request {
 		/// <see href="http://graphql.org/learn/queries/#fields"/>
 		/// </summary>
 		public static GraphQLRequest FieldsRequest1 { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					hero {
 						name
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#fields"/>
 		/// </summary>
 		public static GraphQLRequest FieldsRequest2 { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					hero {
 						name
@@ -31,42 +31,42 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#arguments"/>
 		/// </summary>
 		public static GraphQLRequest ArgumentsRequest1 { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					human(id: ""1000"") {
 						name
 						height
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#arguments"/>
 		/// </summary>
 		public static GraphQLRequest ArgumentsRequest2 { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					human(id: ""1000"") {
 						name
 						height(unit: FOOT)
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#aliases"/>
 		/// </summary>
 		public static GraphQLRequest AliasesRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					empireHero: hero(episode: EMPIRE) {
 						name
@@ -75,14 +75,14 @@ namespace GraphQL.Common.Tests.Request {
 						name
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#fragments"/>
 		/// </summary>
 		public static GraphQLRequest FragmentsRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					leftComparison: hero(episode: EMPIRE) {
 						...comparisonFields
@@ -99,14 +99,14 @@ namespace GraphQL.Common.Tests.Request {
 						name
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#operation-name"/>
 		/// </summary>
 		public static GraphQLRequest OperationNameRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				query HeroNameAndFriends {
 					hero {
 						name
@@ -115,14 +115,14 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 		/// <summary>
 		/// <see href="http://graphql.org/learn/queries/#variables"/>
 		/// </summary>
 		public static GraphQLRequest VariablesRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				query HeroNameAndFriends($episode: Episode) {
 					hero(episode: $episode) {
 						name
@@ -131,7 +131,7 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = new {
+			variables = new {
 				episode = "JEDI"
 			}
 		};
@@ -140,7 +140,7 @@ namespace GraphQL.Common.Tests.Request {
 		/// <see href="http://graphql.org/learn/queries/#directives"/>
 		/// </summary>
 		public static GraphQLRequest DirectivesRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				query Hero($episode: Episode, $withFriends: Boolean!) {
 					hero(episode: $episode) {
 						name
@@ -149,7 +149,7 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = new {
+			variables = new {
 				episode = "JEDI",
 				withFriends = false
 			}
@@ -159,14 +159,14 @@ namespace GraphQL.Common.Tests.Request {
 		/// <see href="http://graphql.org/learn/queries/#mutations"/>
 		/// </summary>
 		public static GraphQLRequest MutationsRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
 					createReview(episode: $ep, review: $review) {
 						stars
 						commentary
 					}
 				}",
-			Variables = new {
+			variables = new {
 				ep = "JEDI",
 				review = new {
 					stars = 5,
@@ -179,7 +179,7 @@ namespace GraphQL.Common.Tests.Request {
 		/// <see href="http://graphql.org/learn/queries/#inline-fragments"/>
 		/// </summary>
 		public static GraphQLRequest InlineFragmentsRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				query HeroForEpisode($ep: Episode!) {
 					hero(episode: $ep) {
 						name
@@ -191,7 +191,7 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = new {
+			variables = new {
 				ep = "JEDI"
 			}
 		};
@@ -200,7 +200,7 @@ namespace GraphQL.Common.Tests.Request {
 		/// <see href="http://graphql.org/learn/queries/#meta-fields"/>
 		/// </summary>
 		public static GraphQLRequest MetaFieldsRequest { get; } = new GraphQLRequest {
-			Query = @"
+			query = @"
 				{
 					search(text: ""an"") {
 						__typename
@@ -215,7 +215,7 @@ namespace GraphQL.Common.Tests.Request {
 						}
 					}
 				}",
-			Variables = null
+			variables = null
 		};
 
 	}

--- a/tests/GraphQL.Common.Tests/Request/GraphQLRequestTests.cs
+++ b/tests/GraphQL.Common.Tests/Request/GraphQLRequestTests.cs
@@ -50,35 +50,35 @@ namespace GraphQL.Common.Tests.Request {
 		public void VariablesRequestFact() {
 			var graphQLRequest = GraphQLRequestConsts.VariablesRequest;
 			AssertGraphQL.CorrectGraphQLRequest(graphQLRequest);
-			Assert.NotNull(graphQLRequest.Variables);
-			Assert.Equal("JEDI", graphQLRequest.Variables.episode);
+			Assert.NotNull(graphQLRequest.variables);
+			Assert.Equal("JEDI", graphQLRequest.variables.episode);
 		}
 
 		[Fact]
 		public void DirectivesRequestFact() {
 			var graphQLRequest = GraphQLRequestConsts.DirectivesRequest;
 			AssertGraphQL.CorrectGraphQLRequest(graphQLRequest);
-			Assert.NotNull(graphQLRequest.Variables);
-			Assert.Equal("JEDI", graphQLRequest.Variables.episode);
-			Assert.Equal(false, graphQLRequest.Variables.withFriends);
+			Assert.NotNull(graphQLRequest.variables);
+			Assert.Equal("JEDI", graphQLRequest.variables.episode);
+			Assert.Equal(false, graphQLRequest.variables.withFriends);
 		}
 
 		[Fact]
 		public void MutationsRequestFact() {
 			var graphQLRequest = GraphQLRequestConsts.MutationsRequest;
 			AssertGraphQL.CorrectGraphQLRequest(graphQLRequest);
-			Assert.NotNull(graphQLRequest.Variables);
-			Assert.Equal("JEDI", graphQLRequest.Variables.ep);
-			Assert.Equal(5, graphQLRequest.Variables.review.stars);
-			Assert.Equal("This is a great movie!", graphQLRequest.Variables.review.commentary);
+			Assert.NotNull(graphQLRequest.variables);
+			Assert.Equal("JEDI", graphQLRequest.variables.ep);
+			Assert.Equal(5, graphQLRequest.variables.review.stars);
+			Assert.Equal("This is a great movie!", graphQLRequest.variables.review.commentary);
 		}
 
 		[Fact]
 		public void InlineFragmentsRequestFact() {
 			var graphQLRequest = GraphQLRequestConsts.InlineFragmentsRequest;
 			AssertGraphQL.CorrectGraphQLRequest(graphQLRequest);
-			Assert.NotNull(graphQLRequest.Variables);
-			Assert.Equal("JEDI", graphQLRequest.Variables.ep);
+			Assert.NotNull(graphQLRequest.variables);
+			Assert.Equal("JEDI", graphQLRequest.variables.ep);
 		}
 
 		[Fact]


### PR DESCRIPTION
Forcing camel casing for all elements by using CamelCasePropertyNamesContractResolver() precludes use of PascalCasing for names of data fields. By changing the names of query, operationName and variables to to comply with the spec the CamelCasePropertyNamesContractResolver is not required.