### PR TITLE
Fix StackOverflowException in GraphQLRequest.GetHashCode()

### DIFF
--- a/src/GraphQL.Common/Request/GraphQLRequest.cs
+++ b/src/GraphQL.Common/Request/GraphQLRequest.cs
@@ -47,7 +47,16 @@ namespace GraphQL.Common.Request {
 		}
 
 		/// <inheritdoc />
-		public override int GetHashCode() => EqualityComparer<GraphQLRequest>.Default.GetHashCode(this);
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var hashCode = EqualityComparer<string?>.Default.GetHashCode(Query);
+				hashCode = (hashCode * 397) ^ EqualityComparer<string?>.Default.GetHashCode(OperationName);
+				hashCode = (hashCode * 397) ^ EqualityComparer<dynamic?>.Default.GetHashCode(Variables);
+				return hashCode;
+			}
+		}
 
 		/// <inheritdoc />
 		public static bool operator ==(GraphQLRequest? request1, GraphQLRequest? request2) => EqualityComparer<GraphQLRequest?>.Default.Equals(request1, request2);


### PR DESCRIPTION
The original `GetHashCode()` method resulted in a `StackOverflowException` on usage.

I created a new implementation (with a little assistance from ReSharper) which seems to work so far.