### PR TITLE
Expose the HttpClient on GraphQLHttpClient

### DIFF
--- a/src/GraphQL.Client/Http/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/Http/GraphQLHttpClient.cs
@@ -19,7 +19,12 @@ namespace GraphQL.Client.Http {
 		/// <summary>
 		/// Gets the headers which should be sent with each request.
 		/// </summary>
-		public HttpRequestHeaders DefaultRequestHeaders => this.graphQLHttpHandler.HttpClient.DefaultRequestHeaders;
+		public HttpRequestHeaders DefaultRequestHeaders => this.HttpClient.DefaultRequestHeaders;
+
+		/// <summary>
+		/// the instance of <see cref="HttpClient"/> which is used internally
+		/// </summary>
+		public HttpClient HttpClient => this.graphQLHttpHandler.HttpClient;
 
 		/// <summary>
 		/// The GraphQL EndPoint to be used
@@ -90,7 +95,12 @@ namespace GraphQL.Client.Http {
 			this.graphQLHttpHandler = new GraphQLHttpHandler(options);
 		}
 
-		internal GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient) {
+		/// <summary>
+		/// Creates a new instance
+		/// </summary>
+		/// <param name="options">The Options to be used</param>
+		/// <param name="httpClient">the <see cref="HttpClient"/> to be used</param>
+		public GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient) {
 			if (options == null) { throw new ArgumentNullException(nameof(options)); }
 			if (options.EndPoint == null) { throw new ArgumentNullException(nameof(options.EndPoint)); }
 			if (options.JsonSerializerSettings == null) { throw new ArgumentNullException(nameof(options.JsonSerializerSettings)); }


### PR DESCRIPTION
Hi, I went on and exposed the `HttpClient` from inside the `GraphQLClient` and also made the constructor accepting a `HttpClient` public (its "exposed" by the `HttpClientExtensions` anyway).

This makes it easier to use the library in combination with DI systems.

Exposing the `HttpClient` as a readonly property has the advantage that existing extension methods from other libraries (like from the [IdentityModel library](https://github.com/IdentityModel/IdentityModel2/blob/master/src/Client/HttpClientExtensions.cs)) can be used with `GraphQLHttpClient` as well.



