### PR TITLE
Use HTTP TLS credentials on WebSocket connection; Send 'connection_init'

### DIFF
--- a/src/GraphQL.Client/GraphQL.Client.csproj
+++ b/src/GraphQL.Client/GraphQL.Client.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="../src.props" />
@@ -6,10 +6,15 @@
 	<PropertyGroup>
 		<Description>A GraphQL Client</Description>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<PackageIconUrl />
 	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\GraphQL.Common\GraphQL.Common.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="../../assets/logo.64x64.png" Pack="true" Visible="false" PackagePath="" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/GraphQL.Client/Http/GraphQLHttpSubscriptionHelpers.cs
+++ b/src/GraphQL.Client/Http/GraphQLHttpSubscriptionHelpers.cs
@@ -94,6 +94,23 @@ namespace GraphQL.Client.Http
 						})
 					);
 
+					var initRequest = new GraphQLWebSocketRequest
+					{
+						Id = startRequest.Id,
+						Type = GQLWebSocketMessageType.GQL_CONNECTION_INIT,
+					};
+					Debug.WriteLine($"sending init on subscription {startRequest.Id}");
+					// send subscription request
+					try
+					{
+						await graphQlHttpWebSocket.SendWebSocketRequest(initRequest).ConfigureAwait(false);
+						//await graphQlHttpWebSocket.SendWebSocketRequest(startRequest);
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine(e);
+						throw;
+					}
 					Debug.WriteLine($"sending initial message on subscription {startRequest.Id}");
 					// send subscription request
 					try

--- a/src/GraphQL.Client/Http/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Http/GraphQLHttpWebSocket.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using GraphQL.Common.Request;
 using GraphQL.Common.Response;
 using Newtonsoft.Json;
+using System.Net.Http;
 
 namespace GraphQL.Client.Http
 {
@@ -125,9 +126,13 @@ namespace GraphQL.Client.Http
 				{
 					case ClientWebSocket nativeWebSocket:
 						nativeWebSocket.Options.AddSubProtocol("graphql-ws");
+						nativeWebSocket.Options.ClientCertificates = ((HttpClientHandler)(_options.HttpMessageHandler)).ClientCertificates;
+						nativeWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)(_options.HttpMessageHandler)).UseDefaultCredentials;
 						break;
 					case System.Net.WebSockets.Managed.ClientWebSocket managedWebSocket:
 						managedWebSocket.Options.AddSubProtocol("graphql-ws");
+						managedWebSocket.Options.ClientCertificates = ((HttpClientHandler)(_options.HttpMessageHandler)).ClientCertificates;
+						managedWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)(_options.HttpMessageHandler)).UseDefaultCredentials;
 						break;
 					default:
 						throw new NotSupportedException($"unknown websocket type {clientWebSocket.GetType().Name}");

--- a/src/GraphQL.Common/GraphQL.Common.csproj
+++ b/src/GraphQL.Common/GraphQL.Common.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="../src.props" />
@@ -9,6 +9,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageIconUrl />
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -16,4 +17,9 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<None Include="../../assets/logo.64x64.png" Pack="true" Visible="false" PackagePath="" />
+	</ItemGroup>
+
+	
 </Project>

--- a/tests/GraphQL.Integration.Tests/SubscriptionsTest.cs
+++ b/tests/GraphQL.Integration.Tests/SubscriptionsTest.cs
@@ -220,6 +220,7 @@ namespace GraphQL.Integration.Tests
 				var tester2 = observable2.SubscribeTester();
 
 				const string message1 = "Hello World";
+				await Task.Delay(200);	// seems to be needed for test to be reliable
 				var response = await client.AddMessageAsync(message1).ConfigureAwait(false);
 				Assert.Equal(message1, (string)response.Data.addMessage.content);
 				tester.ShouldHaveReceivedUpdate(gqlResponse =>


### PR DESCRIPTION
See https://github.com/graphql-dotnet/graphql-client/issues/118
