### PR TITLE
Passing per-request headers

### DIFF
--- a/src/GraphQL.Client.Http/GraphQLHttpRequest.cs
+++ b/src/GraphQL.Client.Http/GraphQLHttpRequest.cs
@@ -1,5 +1,22 @@
+using System;
+using System.Net.Http;
+using System.Text.Json.Serialization;
+
 namespace GraphQL.Client.Http {
 
 	public class GraphQLHttpRequest : GraphQLRequest {
+		public GraphQLHttpRequest()
+		{
+		}
+
+		public GraphQLHttpRequest(string query, object? variables = null, string? operationName = null) : base(query, variables, operationName)
+		{
+		}
+
+		/// <summary>
+		/// Allows to preprocess a <see cref="HttpRequestMessage"/> before it is sent, i.e. add custom headers
+		/// </summary>
+		[JsonIgnore]
+		public Action<HttpRequestMessage> PreprocessHttpRequestMessage { get; set; } = message => { };
 	}
 }

--- a/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Integration.Tests.Helpers
 	public class TestServerSetup : IDisposable
 	{
 		public IWebHost Server { get; set; }
-		public IGraphQLClient Client { get; set; }
+		public GraphQLHttpClient Client { get; set; }
 		public void Dispose()
 		{
 			Server?.Dispose();


### PR DESCRIPTION
fix #72 

```c#

var graphQLRequest = new GraphQLHttpRequest("query string") {
    PreprocessHttpRequestMessage = httpRequestMessage => { /*do something*/ }
};
```