### PR TITLE
Code style unification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,19 +1,256 @@
-# EditorConfig (http://editorconfig.org/)
+# EditorConfig is awesome: http://EditorConfig.org
+
+# Create portable, custom editor settings with EditorConfig
+# https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options
+
+# .NET coding convention settings for EditorConfig
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2019
+
+# Language conventions
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019
+
+# Formatting conventions
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-formatting-conventions?view=vs-2019
+
+# .NET naming conventions for EditorConfig
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2019
+
+# Top-most EditorConfig file
 root = true
 
-# Default Code Style
+# Editor default newlines with a newline ending every file
 [*]
-charset = utf-8
-end_of_line = lf
-indent_size = 4
-indent_style = tab
 insert_final_newline = true
-tab_width = 4
+charset = utf-8
+indent_style = space
+indent_size = 2
 trim_trailing_whitespace = true
 
 [*.cs]
-csharp_new_line_before_open_brace = false
+indent_size = 4
 
-[*.{yaml,yml}]
-indent_size = 2
-indent_style = space
+# Do not insert newline for ApiApprovalTests
+[*.txt]
+insert_final_newline = false
+
+# Code files
+[*.{cs,vb}]
+ 
+# .NET code style settings - "This." and "Me." qualifiers
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#this-and-me
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# .NET code style settings - Language keywords instead of framework type names for type references
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#language-keywords
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
+
+# .NET code style settings - Modifier preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#normalize-modifiers
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+dotnet_style_readonly_field = true:warning
+
+# .NET code style settings - Parentheses preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#parentheses-preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# .NET code style settings - Expression-level preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#expression-level-preferences
+dotnet_style_object_initializer = true:error
+dotnet_style_collection_initializer = true:error
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+
+# .NET code style settings - Null-checking preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#null-checking-preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:error
+
+# .NET code quality settings - Parameter preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#parameter-preferences
+dotnet_code_quality_unused_parameters = all:warning
+
+# C# code style settings - Implicit and explicit types
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#implicit-and-explicit-types
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:suggestion
+
+# C# code style settings - Expression-bodied members
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#expression-bodied-members
+csharp_style_expression_bodied_methods = when_on_single_line:warning
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = when_on_single_line:warning
+csharp_style_expression_bodied_properties = when_on_single_line:warning
+csharp_style_expression_bodied_indexers = when_on_single_line:warning
+csharp_style_expression_bodied_accessors = when_on_single_line:warning
+csharp_style_expression_bodied_lambdas = when_on_single_line:warning
+csharp_style_expression_bodied_local_functions = when_on_single_line:warning
+
+# C# code style settings - Pattern matching
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#pattern-matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+
+# C# code style settings - Inlined variable declaration
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#inlined-variable-declarations
+csharp_style_inlined_variable_declaration = true:error
+
+# C# code style settings - C# expression-level preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#c-expression-level-preferences
+csharp_prefer_simple_default_expression = true:suggestion
+
+# C# code style settings - C# null-checking preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#c-null-checking-preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+
+# C# code style settings - Code block preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#code-block-preferences
+csharp_prefer_braces = false:suggestion
+
+# C# code style - Unused value preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#unused-value-preferences
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+
+# C# code style - Index and range preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#index-and-range-preferences
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+
+# C# code style - Miscellaneous preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-language-conventions?view=vs-2019#miscellaneous-preferences
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# .NET formatting settings - Organize using directives
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-formatting-conventions?view=vs-2019#organize-using-directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# C# formatting settings - New-line options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-formatting-conventions?view=vs-2019#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# C# formatting settings - Indentation options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-formatting-conventions?view=vs-2019#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+
+# C# formatting settings - Spacing options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+# C# formatting settings - Wrap options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-formatting-conventions?view=vs-2019#wrap-options
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+########## name all private fields using camelCase with underscore prefix ##########
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2019
+# dotnet_naming_rule.<namingRuleTitle>.symbols = <symbolTitle>
+dotnet_naming_rule.private_fields_with_underscore.symbols = private_fields
+ 
+# dotnet_naming_symbols.<symbolTitle>.<property> = <value>
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+ 
+# dotnet_naming_rule.<namingRuleTitle>.style = <styleTitle>
+dotnet_naming_rule.private_fields_with_underscore.style = prefix_underscore
+ 
+# dotnet_naming_style.<styleTitle>.<property> = <value>
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+ 
+# dotnet_naming_rule.<namingRuleTitle>.severity = <value>
+dotnet_naming_rule.private_fields_with_underscore.severity = warning
+
+########## name all constant fields using UPPER_CASE ##########
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2019
+# dotnet_naming_rule.<namingRuleTitle>.symbols = <symbolTitle>
+dotnet_naming_rule.constant_fields_should_be_upper_case.symbols = constant_fields
+
+# dotnet_naming_symbols.<symbolTitle>.<property> = <value>
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+# dotnet_naming_rule.<namingRuleTitle>.style = <styleTitle>
+dotnet_naming_rule.constant_fields_should_be_upper_case.style = upper_case_style
+
+# dotnet_naming_style.<styleTitle>.<property> = <value>
+dotnet_naming_style.upper_case_style.capitalization = all_upper
+dotnet_naming_style.upper_case_style.word_separator = _
+
+# dotnet_naming_rule.<namingRuleTitle>.severity = <value>
+dotnet_naming_rule.constant_fields_should_be_upper_case.severity = warning
+
+########## Async methods should have "Async" suffix ##########
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2019
+# dotnet_naming_rule.<namingRuleTitle>.symbols = <symbolTitle>
+dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
+
+# dotnet_naming_symbols.<symbolTitle>.<property> = <value>
+dotnet_naming_symbols.any_async_methods.applicable_kinds = method
+dotnet_naming_symbols.any_async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.any_async_methods.required_modifiers = async
+
+# dotnet_naming_rule.<namingRuleTitle>.style = <styleTitle>
+dotnet_naming_rule.async_methods_end_in_async.style = end_in_async_style
+
+# dotnet_naming_style.<styleTitle>.<property> = <value>
+dotnet_naming_style.end_in_async_style.capitalization = pascal_case
+dotnet_naming_style.end_in_async_style.word_separator = 
+dotnet_naming_style.end_in_async_style.required_prefix = 
+dotnet_naming_style.end_in_async_style.required_suffix = Async
+
+# dotnet_naming_rule.<namingRuleTitle>.severity = <value>
+dotnet_naming_rule.async_methods_end_in_async.severity = warning

--- a/examples/GraphQL.Client.Example/PersonAndFilmsResponse.cs
+++ b/examples/GraphQL.Client.Example/PersonAndFilmsResponse.cs
@@ -2,20 +2,24 @@ using System.Collections.Generic;
 
 namespace GraphQL.Client.Http.Examples
 {
-	public class PersonAndFilmsResponse {
-		public PersonContent Person { get; set; }
+    public class PersonAndFilmsResponse
+    {
+        public PersonContent Person { get; set; }
 
-		public class PersonContent {
-			public string Name { get; set; }
-			public FilmConnectionContent FilmConnection { get; set; }
+        public class PersonContent
+        {
+            public string Name { get; set; }
+            public FilmConnectionContent FilmConnection { get; set; }
 
-			public class FilmConnectionContent {
-				public List<FilmContent> Films { get; set; }
+            public class FilmConnectionContent
+            {
+                public List<FilmContent> Films { get; set; }
 
-				public class FilmContent {
-					public string Title { get; set; }
-				}
-			}
-		}
-	}
+                public class FilmContent
+                {
+                    public string Title { get; set; }
+                }
+            }
+        }
+    }
 }

--- a/examples/GraphQL.Client.Example/PersonAndFilmsResponse.cs
+++ b/examples/GraphQL.Client.Example/PersonAndFilmsResponse.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace GraphQL.Client.Http.Examples
+namespace GraphQL.Client.Example
 {
     public class PersonAndFilmsResponse
     {

--- a/examples/GraphQL.Client.Example/Program.cs
+++ b/examples/GraphQL.Client.Example/Program.cs
@@ -4,16 +4,20 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using GraphQL.Client.Serializer.Newtonsoft;
 
-namespace GraphQL.Client.Http.Examples {
+namespace GraphQL.Client.Http.Examples
+{
 
-	public class Program {
+    public class Program
+    {
 
-		public static async Task Main(string[] args) {
+        public static async Task Main(string[] args)
+        {
 
-			using var graphQLClient = new GraphQLHttpClient("https://swapi.apis.guru/");
+            using var graphQLClient = new GraphQLHttpClient("https://swapi.apis.guru/");
 
-			var personAndFilmsRequest = new GraphQLRequest {
-				Query = @"
+            var personAndFilmsRequest = new GraphQLRequest
+            {
+                Query = @"
 			    query PersonAndFilms($id: ID) {
 			        person(id: $id) {
 			            name
@@ -24,25 +28,26 @@ namespace GraphQL.Client.Http.Examples {
 			            }
 			        }
 			    }",
-				OperationName = "PersonAndFilms",
-				Variables = new {
-					id = "cGVvcGxlOjE="
-				}
-			};
+                OperationName = "PersonAndFilms",
+                Variables = new
+                {
+                    id = "cGVvcGxlOjE="
+                }
+            };
 
-			var graphQLResponse = await graphQLClient.SendQueryAsync<PersonAndFilmsResponse>(personAndFilmsRequest);
-			Console.WriteLine("raw response:");
-			Console.WriteLine(JsonSerializer.Serialize(graphQLResponse, new JsonSerializerOptions { WriteIndented = true }));
+            var graphQLResponse = await graphQLClient.SendQueryAsync<PersonAndFilmsResponse>(personAndFilmsRequest);
+            Console.WriteLine("raw response:");
+            Console.WriteLine(JsonSerializer.Serialize(graphQLResponse, new JsonSerializerOptions { WriteIndented = true }));
 
-			Console.WriteLine();
-			Console.WriteLine($"Name: {graphQLResponse.Data.Person.Name}" );
-			var films = string.Join(", ", graphQLResponse.Data.Person.FilmConnection.Films.Select(f => f.Title));
-			Console.WriteLine($"Films: {films}");
+            Console.WriteLine();
+            Console.WriteLine($"Name: {graphQLResponse.Data.Person.Name}");
+            var films = string.Join(", ", graphQLResponse.Data.Person.FilmConnection.Films.Select(f => f.Title));
+            Console.WriteLine($"Films: {films}");
 
-			Console.WriteLine();
-			Console.WriteLine("Press any key to quit...");
-			Console.ReadKey();
-		}
+            Console.WriteLine();
+            Console.WriteLine("Press any key to quit...");
+            Console.ReadKey();
+        }
 
-	}
+    }
 }

--- a/examples/GraphQL.Client.Example/Program.cs
+++ b/examples/GraphQL.Client.Example/Program.cs
@@ -2,9 +2,9 @@ using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using GraphQL.Client.Serializer.Newtonsoft;
+using GraphQL.Client.Http;
 
-namespace GraphQL.Client.Http.Examples
+namespace GraphQL.Client.Example
 {
 
     public class Program
@@ -12,7 +12,7 @@ namespace GraphQL.Client.Http.Examples
 
         public static async Task Main(string[] args)
         {
-
+            _ = args;
             using var graphQLClient = new GraphQLHttpClient("https://swapi.apis.guru/");
 
             var personAndFilmsRequest = new GraphQLRequest

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketMessageType.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketMessageType.cs
@@ -1,87 +1,89 @@
-namespace GraphQL.Client.Abstractions.Websocket {
-	public static class GraphQLWebSocketMessageType {
+namespace GraphQL.Client.Abstractions.Websocket
+{
+    public static class GraphQLWebSocketMessageType
+    {
 
-		/// <summary>
-		///     Client sends this message after plain websocket connection to start the communication with the server
-		///     The server will response only with GQL_CONNECTION_ACK + GQL_CONNECTION_KEEP_ALIVE(if used) or GQL_CONNECTION_ERROR
-		///     to this message.
-		///     payload: Object : optional parameters that the client specifies in connectionParams
-		/// </summary>
-		public const string GQL_CONNECTION_INIT = "connection_init";
+        /// <summary>
+        ///     Client sends this message after plain websocket connection to start the communication with the server
+        ///     The server will response only with GQL_CONNECTION_ACK + GQL_CONNECTION_KEEP_ALIVE(if used) or GQL_CONNECTION_ERROR
+        ///     to this message.
+        ///     payload: Object : optional parameters that the client specifies in connectionParams
+        /// </summary>
+        public const string GQL_CONNECTION_INIT = "connection_init";
 
-		/// <summary>
-		///     The server may responses with this message to the GQL_CONNECTION_INIT from client, indicates the server accepted
-		///     the connection.
-		/// </summary>
-		public const string GQL_CONNECTION_ACK = "connection_ack"; // Server -> Client
+        /// <summary>
+        ///     The server may responses with this message to the GQL_CONNECTION_INIT from client, indicates the server accepted
+        ///     the connection.
+        /// </summary>
+        public const string GQL_CONNECTION_ACK = "connection_ack"; // Server -> Client
 
-		/// <summary>
-		///     The server may responses with this message to the GQL_CONNECTION_INIT from client, indicates the server rejected
-		///     the connection.
-		///     It server also respond with this message in case of a parsing errors of the message (which does not disconnect the
-		///     client, just ignore the message).
-		///     payload: Object: the server side error
-		/// </summary>
-		public const string GQL_CONNECTION_ERROR = "connection_error"; // Server -> Client
+        /// <summary>
+        ///     The server may responses with this message to the GQL_CONNECTION_INIT from client, indicates the server rejected
+        ///     the connection.
+        ///     It server also respond with this message in case of a parsing errors of the message (which does not disconnect the
+        ///     client, just ignore the message).
+        ///     payload: Object: the server side error
+        /// </summary>
+        public const string GQL_CONNECTION_ERROR = "connection_error"; // Server -> Client
 
-		/// <summary>
-		///     Server message that should be sent right after each GQL_CONNECTION_ACK processed and then periodically to keep the
-		///     client connection alive.
-		///     The client starts to consider the keep alive message only upon the first received keep alive message from the
-		///     server.
-		///     <remarks>
-		///         NOTE: This one here don't follow the standard due to connection optimization
-		///     </remarks>
-		/// </summary>
-		public const string GQL_CONNECTION_KEEP_ALIVE = "ka"; // Server -> Client
+        /// <summary>
+        ///     Server message that should be sent right after each GQL_CONNECTION_ACK processed and then periodically to keep the
+        ///     client connection alive.
+        ///     The client starts to consider the keep alive message only upon the first received keep alive message from the
+        ///     server.
+        ///     <remarks>
+        ///         NOTE: This one here don't follow the standard due to connection optimization
+        ///     </remarks>
+        /// </summary>
+        public const string GQL_CONNECTION_KEEP_ALIVE = "ka"; // Server -> Client
 
-		/// <summary>
-		///     Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
-		///     id: string : operation id
-		/// </summary>
-		public const string GQL_CONNECTION_TERMINATE = "connection_terminate"; // Client -> Server
+        /// <summary>
+        ///     Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
+        ///     id: string : operation id
+        /// </summary>
+        public const string GQL_CONNECTION_TERMINATE = "connection_terminate"; // Client -> Server
 
-		/// <summary>
-		///     Client sends this message to execute GraphQL operation
-		///     id: string : The id of the GraphQL operation to start
-		///     payload: Object:
-		///     query: string : GraphQL operation as string or parsed GraphQL document node
-		///     variables?: Object : Object with GraphQL variables
-		///     operationName?: string : GraphQL operation name
-		/// </summary>
-		public const string GQL_START = "start";
+        /// <summary>
+        ///     Client sends this message to execute GraphQL operation
+        ///     id: string : The id of the GraphQL operation to start
+        ///     payload: Object:
+        ///     query: string : GraphQL operation as string or parsed GraphQL document node
+        ///     variables?: Object : Object with GraphQL variables
+        ///     operationName?: string : GraphQL operation name
+        /// </summary>
+        public const string GQL_START = "start";
 
-		/// <summary>
-		///     The server sends this message to transfer the GraphQL execution result from the server to the client, this message
-		///     is a response for GQL_START message.
-		///     For each GraphQL operation send with GQL_START, the server will respond with at least one GQL_DATA message.
-		///     id: string : ID of the operation that was successfully set up
-		///     payload: Object :
-		///     data: any: Execution result
-		///     errors?: Error[] : Array of resolvers errors
-		/// </summary>
-		public const string GQL_DATA = "data"; // Server -> Client
+        /// <summary>
+        ///     The server sends this message to transfer the GraphQL execution result from the server to the client, this message
+        ///     is a response for GQL_START message.
+        ///     For each GraphQL operation send with GQL_START, the server will respond with at least one GQL_DATA message.
+        ///     id: string : ID of the operation that was successfully set up
+        ///     payload: Object :
+        ///     data: any: Execution result
+        ///     errors?: Error[] : Array of resolvers errors
+        /// </summary>
+        public const string GQL_DATA = "data"; // Server -> Client
 
-		/// <summary>
-		///     Server sends this message upon a failing operation, before the GraphQL execution, usually due to GraphQL validation
-		///     errors (resolver errors are part of GQL_DATA message, and will be added as errors array)
-		///     payload: Error : payload with the error attributed to the operation failing on the server
-		///     id: string : operation ID of the operation that failed on the server
-		/// </summary>
-		public const string GQL_ERROR = "error"; // Server -> Client
+        /// <summary>
+        ///     Server sends this message upon a failing operation, before the GraphQL execution, usually due to GraphQL validation
+        ///     errors (resolver errors are part of GQL_DATA message, and will be added as errors array)
+        ///     payload: Error : payload with the error attributed to the operation failing on the server
+        ///     id: string : operation ID of the operation that failed on the server
+        /// </summary>
+        public const string GQL_ERROR = "error"; // Server -> Client
 
-		/// <summary>
-		///     Server sends this message to indicate that a GraphQL operation is done, and no more data will arrive for the
-		///     specific operation.
-		///     id: string : operation ID of the operation that completed
-		/// </summary>
-		public const string GQL_COMPLETE = "complete"; // Server -> Client
+        /// <summary>
+        ///     Server sends this message to indicate that a GraphQL operation is done, and no more data will arrive for the
+        ///     specific operation.
+        ///     id: string : operation ID of the operation that completed
+        /// </summary>
+        public const string GQL_COMPLETE = "complete"; // Server -> Client
 
-		/// <summary>
-		///     Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
-		///     id: string : operation id
-		/// </summary>
-		public const string GQL_STOP = "stop"; // Client -> Server
+        /// <summary>
+        ///     Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
+        ///     id: string : operation id
+        /// </summary>
+        public const string GQL_STOP = "stop"; // Client -> Server
 
-	}
+    }
 }

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -3,102 +3,114 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
-namespace GraphQL.Client.Abstractions.Websocket {
+namespace GraphQL.Client.Abstractions.Websocket
+{
 
-	/// <summary>
-	/// A Subscription Request
-	/// </summary>
-	public class GraphQLWebSocketRequest : Dictionary<string, object>, IEquatable<GraphQLWebSocketRequest> {
-		public const string IdKey = "id";
-		public const string TypeKey = "type";
-		public const string PayloadKey = "payload";
+    /// <summary>
+    /// A Subscription Request
+    /// </summary>
+    public class GraphQLWebSocketRequest : Dictionary<string, object>, IEquatable<GraphQLWebSocketRequest>
+    {
+        public const string IdKey = "id";
+        public const string TypeKey = "type";
+        public const string PayloadKey = "payload";
 
-		/// <summary>
-		/// The Identifier of the Response
-		/// </summary>
-		public string Id {
-			get => ContainsKey(IdKey) ? (string)this[IdKey] : null;
-			set => this[IdKey] = value;
-		}
+        /// <summary>
+        /// The Identifier of the Response
+        /// </summary>
+        public string Id
+        {
+            get => ContainsKey(IdKey) ? (string)this[IdKey] : null;
+            set => this[IdKey] = value;
+        }
 
-		/// <summary>
-		/// The Type of the Request
-		/// </summary>
-		public string Type {
-			get => ContainsKey(TypeKey) ? (string)this[TypeKey] : null;
-			set => this[TypeKey] = value;
-		}
+        /// <summary>
+        /// The Type of the Request
+        /// </summary>
+        public string Type
+        {
+            get => ContainsKey(TypeKey) ? (string)this[TypeKey] : null;
+            set => this[TypeKey] = value;
+        }
 
-		/// <summary>
-		/// The payload of the websocket request
-		/// </summary>
-		public GraphQLRequest Payload {
-			get => ContainsKey(PayloadKey) ? (GraphQLRequest) this[PayloadKey] : null;
-			set => this[PayloadKey] = value;
-		}
+        /// <summary>
+        /// The payload of the websocket request
+        /// </summary>
+        public GraphQLRequest Payload
+        {
+            get => ContainsKey(PayloadKey) ? (GraphQLRequest)this[PayloadKey] : null;
+            set => this[PayloadKey] = value;
+        }
 
-		private TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
 
-		/// <summary>
-		/// Task used to await the actual send operation and to convey potential exceptions
-		/// </summary>
-		/// <returns></returns>
-		public Task SendTask() => _tcs.Task;
+        /// <summary>
+        /// Task used to await the actual send operation and to convey potential exceptions
+        /// </summary>
+        /// <returns></returns>
+        public Task SendTask() => _tcs.Task;
 
-		/// <summary>
-		/// gets called when the send operation for this request has completed sucessfully
-		/// </summary>
-		public void SendCompleted() => _tcs.SetResult(true);
+        /// <summary>
+        /// gets called when the send operation for this request has completed sucessfully
+        /// </summary>
+        public void SendCompleted() => _tcs.SetResult(true);
 
-		/// <summary>
-		/// gets called when an exception occurs during the send operation
-		/// </summary>
-		/// <param name="e"></param>
-		public void SendFailed(Exception e) => _tcs.SetException(e);
+        /// <summary>
+        /// gets called when an exception occurs during the send operation
+        /// </summary>
+        /// <param name="e"></param>
+        public void SendFailed(Exception e) => _tcs.SetException(e);
 
-		/// <summary>
-		/// gets called when the GraphQLHttpWebSocket has been disposed before the send operation for this request has started
-		/// </summary>
-		public void SendCanceled() => _tcs.SetCanceled();
+        /// <summary>
+        /// gets called when the GraphQLHttpWebSocket has been disposed before the send operation for this request has started
+        /// </summary>
+        public void SendCanceled() => _tcs.SetCanceled();
 
-		/// <inheritdoc />
-		public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketRequest);
+        /// <inheritdoc />
+        public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketRequest);
 
-		/// <inheritdoc />
-		public bool Equals(GraphQLWebSocketRequest other) {
-			if (other == null) {
-				return false;
-			}
-			if (ReferenceEquals(this, other)) {
-				return true;
-			}
-			if (!Equals(this.Id, other.Id)) {
-				return false;
-			}
-			if (!Equals(this.Type, other.Type)) {
-				return false;
-			}
-			if (!Equals(this.Payload, other.Payload)) {
-				return false;
-			}
-			return true;
-		}
+        /// <inheritdoc />
+        public bool Equals(GraphQLWebSocketRequest other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            if (!Equals(this.Id, other.Id))
+            {
+                return false;
+            }
+            if (!Equals(this.Type, other.Type))
+            {
+                return false;
+            }
+            if (!Equals(this.Payload, other.Payload))
+            {
+                return false;
+            }
+            return true;
+        }
 
-		/// <inheritdoc />
-		public override int GetHashCode() {
-			var hashCode = 9958074;
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
-			hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(this.Payload);
-			return hashCode;
-		}
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hashCode = 9958074;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
+            hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(this.Payload);
+            return hashCode;
+        }
 
-		/// <inheritdoc />
-		public static bool operator ==(GraphQLWebSocketRequest request1, GraphQLWebSocketRequest request2) => EqualityComparer<GraphQLWebSocketRequest>.Default.Equals(request1, request2);
+        /// <inheritdoc />
+        public static bool operator ==(GraphQLWebSocketRequest request1, GraphQLWebSocketRequest request2) => EqualityComparer<GraphQLWebSocketRequest>.Default.Equals(request1, request2);
 
-		/// <inheritdoc />
-		public static bool operator !=(GraphQLWebSocketRequest request1, GraphQLWebSocketRequest request2) => !(request1 == request2);
+        /// <inheritdoc />
+        public static bool operator !=(GraphQLWebSocketRequest request1, GraphQLWebSocketRequest request2) => !(request1 == request2);
 
-	}
+    }
 
 }

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 namespace GraphQL.Client.Abstractions.Websocket
@@ -11,17 +10,17 @@ namespace GraphQL.Client.Abstractions.Websocket
     /// </summary>
     public class GraphQLWebSocketRequest : Dictionary<string, object>, IEquatable<GraphQLWebSocketRequest>
     {
-        public const string IdKey = "id";
-        public const string TypeKey = "type";
-        public const string PayloadKey = "payload";
+        public const string ID_KEY = "id";
+        public const string TYPE_KEY = "type";
+        public const string PAYLOAD_KEY = "payload";
 
         /// <summary>
         /// The Identifier of the Response
         /// </summary>
         public string Id
         {
-            get => ContainsKey(IdKey) ? (string)this[IdKey] : null;
-            set => this[IdKey] = value;
+            get => ContainsKey(ID_KEY) ? (string)this[ID_KEY] : null;
+            set => this[ID_KEY] = value;
         }
 
         /// <summary>
@@ -29,8 +28,8 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// </summary>
         public string Type
         {
-            get => ContainsKey(TypeKey) ? (string)this[TypeKey] : null;
-            set => this[TypeKey] = value;
+            get => ContainsKey(TYPE_KEY) ? (string)this[TYPE_KEY] : null;
+            set => this[TYPE_KEY] = value;
         }
 
         /// <summary>
@@ -38,11 +37,11 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// </summary>
         public GraphQLRequest Payload
         {
-            get => ContainsKey(PayloadKey) ? (GraphQLRequest)this[PayloadKey] : null;
-            set => this[PayloadKey] = value;
+            get => ContainsKey(PAYLOAD_KEY) ? (GraphQLRequest)this[PAYLOAD_KEY] : null;
+            set => this[PAYLOAD_KEY] = value;
         }
 
-        private TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
 
         /// <summary>
         /// Task used to await the actual send operation and to convey potential exceptions
@@ -67,7 +66,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         public void SendCanceled() => _tcs.SetCanceled();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketRequest);
+        public override bool Equals(object obj) => Equals(obj as GraphQLWebSocketRequest);
 
         /// <inheritdoc />
         public bool Equals(GraphQLWebSocketRequest other)
@@ -80,15 +79,15 @@ namespace GraphQL.Client.Abstractions.Websocket
             {
                 return true;
             }
-            if (!Equals(this.Id, other.Id))
+            if (!Equals(Id, other.Id))
             {
                 return false;
             }
-            if (!Equals(this.Type, other.Type))
+            if (!Equals(Type, other.Type))
             {
                 return false;
             }
-            if (!Equals(this.Payload, other.Payload))
+            if (!Equals(Payload, other.Payload))
             {
                 return false;
             }
@@ -99,9 +98,9 @@ namespace GraphQL.Client.Abstractions.Websocket
         public override int GetHashCode()
         {
             var hashCode = 9958074;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
-            hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(this.Payload);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Type);
+            hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(Payload);
             return hashCode;
         }
 

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketResponse.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketResponse.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         public string Type { get; set; }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketResponse);
+        public override bool Equals(object obj) => Equals(obj as GraphQLWebSocketResponse);
 
         /// <inheritdoc />
         public bool Equals(GraphQLWebSocketResponse other)
@@ -36,12 +36,12 @@ namespace GraphQL.Client.Abstractions.Websocket
                 return true;
             }
 
-            if (!Equals(this.Id, other.Id))
+            if (!Equals(Id, other.Id))
             {
                 return false;
             }
 
-            if (!Equals(this.Type, other.Type))
+            if (!Equals(Type, other.Type))
             {
                 return false;
             }
@@ -53,8 +53,8 @@ namespace GraphQL.Client.Abstractions.Websocket
         public override int GetHashCode()
         {
             var hashCode = 9958074;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Type);
             return hashCode;
         }
 
@@ -74,7 +74,7 @@ namespace GraphQL.Client.Abstractions.Websocket
 
         public bool Equals(GraphQLWebSocketResponse<TPayload>? other)
         {
-            if (ReferenceEquals(null, other))
+            if (other is null)
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
@@ -83,11 +83,11 @@ namespace GraphQL.Client.Abstractions.Websocket
 
         public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
             if (ReferenceEquals(this, obj))
                 return true;
-            if (obj.GetType() != this.GetType())
+            if (obj.GetType() != GetType())
                 return false;
             return Equals((GraphQLWebSocketResponse<TPayload>)obj);
         }

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketResponse.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketResponse.cs
@@ -1,85 +1,103 @@
 using System;
 using System.Collections.Generic;
 
-namespace GraphQL.Client.Abstractions.Websocket {
+namespace GraphQL.Client.Abstractions.Websocket
+{
 
-	/// <summary>
-	/// A Subscription Response
-	/// </summary>
-	public class GraphQLWebSocketResponse : IEquatable<GraphQLWebSocketResponse> {
+    /// <summary>
+    /// A Subscription Response
+    /// </summary>
+    public class GraphQLWebSocketResponse : IEquatable<GraphQLWebSocketResponse>
+    {
 
-		/// <summary>
-		/// The Identifier of the Response
-		/// </summary>
-		public string Id { get; set; }
+        /// <summary>
+        /// The Identifier of the Response
+        /// </summary>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// The Type of the Response
-		/// </summary>
-		public string Type { get; set; }
+        /// <summary>
+        /// The Type of the Response
+        /// </summary>
+        public string Type { get; set; }
 
-		/// <inheritdoc />
-		public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketResponse);
+        /// <inheritdoc />
+        public override bool Equals(object obj) => this.Equals(obj as GraphQLWebSocketResponse);
 
-		/// <inheritdoc />
-		public bool Equals(GraphQLWebSocketResponse other) {
-			if (other == null) {
-				return false;
-			}
+        /// <inheritdoc />
+        public bool Equals(GraphQLWebSocketResponse other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
 
-			if (ReferenceEquals(this, other)) {
-				return true;
-			}
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
 
-			if (!Equals(this.Id, other.Id)) {
-				return false;
-			}
+            if (!Equals(this.Id, other.Id))
+            {
+                return false;
+            }
 
-			if (!Equals(this.Type, other.Type)) {
-				return false;
-			}
+            if (!Equals(this.Type, other.Type))
+            {
+                return false;
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		/// <inheritdoc />
-		public override int GetHashCode() {
-			var hashCode = 9958074;
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
-			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
-			return hashCode;
-		}
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hashCode = 9958074;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Type);
+            return hashCode;
+        }
 
-		/// <inheritdoc />
-		public static bool operator ==(GraphQLWebSocketResponse response1, GraphQLWebSocketResponse response2) =>
-			EqualityComparer<GraphQLWebSocketResponse>.Default.Equals(response1, response2);
+        /// <inheritdoc />
+        public static bool operator ==(GraphQLWebSocketResponse response1, GraphQLWebSocketResponse response2) =>
+            EqualityComparer<GraphQLWebSocketResponse>.Default.Equals(response1, response2);
 
-		/// <inheritdoc />
-		public static bool operator !=(GraphQLWebSocketResponse response1, GraphQLWebSocketResponse response2) =>
-			!(response1 == response2);
+        /// <inheritdoc />
+        public static bool operator !=(GraphQLWebSocketResponse response1, GraphQLWebSocketResponse response2) =>
+            !(response1 == response2);
 
-	}
+    }
 
-	public class GraphQLWebSocketResponse<TPayload> : GraphQLWebSocketResponse, IEquatable<GraphQLWebSocketResponse<TPayload>> {
-		public TPayload Payload { get; set; }
+    public class GraphQLWebSocketResponse<TPayload> : GraphQLWebSocketResponse, IEquatable<GraphQLWebSocketResponse<TPayload>>
+    {
+        public TPayload Payload { get; set; }
 
-		public bool Equals(GraphQLWebSocketResponse<TPayload>? other) {
-			if (ReferenceEquals(null, other)) return false;
-			if (ReferenceEquals(this, other)) return true;
-			return base.Equals(other) && Payload.Equals(other.Payload);
-		}
+        public bool Equals(GraphQLWebSocketResponse<TPayload>? other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return base.Equals(other) && Payload.Equals(other.Payload);
+        }
 
-		public override bool Equals(object? obj) {
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			if (obj.GetType() != this.GetType()) return false;
-			return Equals((GraphQLWebSocketResponse<TPayload>)obj);
-		}
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((GraphQLWebSocketResponse<TPayload>)obj);
+        }
 
-		public override int GetHashCode() {
-			unchecked {
-				return (base.GetHashCode() * 397) ^ Payload.GetHashCode();
-			}
-		}
-	}
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (base.GetHashCode() * 397) ^ Payload.GetHashCode();
+            }
+        }
+    }
 }

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebsocketConnectionState.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebsocketConnectionState.cs
@@ -1,7 +1,9 @@
-namespace GraphQL.Client.Abstractions.Websocket {
-	public enum GraphQLWebsocketConnectionState {
-		Disconnected,
-		Connecting,
-		Connected
-	}
+namespace GraphQL.Client.Abstractions.Websocket
+{
+    public enum GraphQLWebsocketConnectionState
+    {
+        Disconnected,
+        Connecting,
+        Connected
+    }
 }

--- a/src/GraphQL.Client.Abstractions.Websocket/IGraphQLWebsocketJsonSerializer.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/IGraphQLWebsocketJsonSerializer.cs
@@ -3,15 +3,16 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Client.Abstractions.Websocket
 {
-	/// <summary>
-	/// The json serializer interface for the graphql-dotnet http client.
-	/// Implementations should provide a parameterless constructor for convenient usage
-	/// </summary>
-    public interface IGraphQLWebsocketJsonSerializer: IGraphQLJsonSerializer {
-	    byte[] SerializeToBytes(GraphQLWebSocketRequest request);
+    /// <summary>
+    /// The json serializer interface for the graphql-dotnet http client.
+    /// Implementations should provide a parameterless constructor for convenient usage
+    /// </summary>
+    public interface IGraphQLWebsocketJsonSerializer : IGraphQLJsonSerializer
+    {
+        byte[] SerializeToBytes(GraphQLWebSocketRequest request);
 
-	    Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream);
-	    GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes);
+        Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream);
+        GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes);
 
-	}
+    }
 }

--- a/src/GraphQL.Client.Abstractions.Websocket/WebsocketMessageWrapper.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/WebsocketMessageWrapper.cs
@@ -1,9 +1,11 @@
 using System.Runtime.Serialization;
 
-namespace GraphQL.Client.Abstractions.Websocket {
-	public class WebsocketMessageWrapper : GraphQLWebSocketResponse {
+namespace GraphQL.Client.Abstractions.Websocket
+{
+    public class WebsocketMessageWrapper : GraphQLWebSocketResponse
+    {
 
-		[IgnoreDataMember]
-		public byte[] MessageBytes { get; set; }
-	}
+        [IgnoreDataMember]
+        public byte[] MessageBytes { get; set; }
+    }
 }

--- a/src/GraphQL.Client.Abstractions/GraphQLClientExtensions.cs
+++ b/src/GraphQL.Client.Abstractions/GraphQLClientExtensions.cs
@@ -10,29 +10,46 @@ namespace GraphQL.Client.Abstractions
             string query, object? variables = null,
             string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default)
         {
-            return client.SendQueryAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
+            _ = defineResponseType;
+            return client.SendQueryAsync<TResponse>(new GraphQLRequest(query, variables, operationName),
+                cancellationToken: cancellationToken);
         }
+
         public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
             string query, object? variables = null,
             string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default)
         {
-            return client.SendMutationAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
+            _ = defineResponseType;
+            return client.SendMutationAsync<TResponse>(new GraphQLRequest(query, variables, operationName),
+                cancellationToken: cancellationToken);
         }
 
         public static Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(this IGraphQLClient client,
             GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
-            => client.SendQueryAsync<TResponse>(request, cancellationToken);
+        {
+            _ = defineResponseType;
+            return client.SendQueryAsync<TResponse>(request, cancellationToken);
+        }
 
         public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
             GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
-            => client.SendMutationAsync<TResponse>(request, cancellationToken);
+        {
+            _ = defineResponseType;
+            return client.SendMutationAsync<TResponse>(request, cancellationToken);
+        }
 
         public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
             this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType)
-            => client.CreateSubscriptionStream<TResponse>(request);
+        {
+            _ = defineResponseType;
+            return client.CreateSubscriptionStream<TResponse>(request);
+        }
 
         public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
             this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<Exception> exceptionHandler)
-            => client.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
+        {
+            _ = defineResponseType;
+            return client.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
+        }
     }
 }

--- a/src/GraphQL.Client.Abstractions/GraphQLClientExtensions.cs
+++ b/src/GraphQL.Client.Abstractions/GraphQLClientExtensions.cs
@@ -2,33 +2,37 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GraphQL.Client.Abstractions {
-	public static class GraphQLClientExtensions {
-		public static Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(this IGraphQLClient client,
-			string query, object? variables = null,
-			string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default) {
-			return client.SendQueryAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
-		}
-		public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
-			string query, object? variables = null,
-			string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default) {
-			return client.SendMutationAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
-		}
+namespace GraphQL.Client.Abstractions
+{
+    public static class GraphQLClientExtensions
+    {
+        public static Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(this IGraphQLClient client,
+            string query, object? variables = null,
+            string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default)
+        {
+            return client.SendQueryAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
+        }
+        public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
+            string query, object? variables = null,
+            string? operationName = null, Func<TResponse> defineResponseType = null, CancellationToken cancellationToken = default)
+        {
+            return client.SendMutationAsync<TResponse>(new GraphQLRequest(query, variables, operationName), cancellationToken: cancellationToken);
+        }
 
-		public static Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(this IGraphQLClient client,
-			GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
-			=> client.SendQueryAsync<TResponse>(request, cancellationToken);
+        public static Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(this IGraphQLClient client,
+            GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
+            => client.SendQueryAsync<TResponse>(request, cancellationToken);
 
-		public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
-			GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
-			=> client.SendMutationAsync<TResponse>(request, cancellationToken);
+        public static Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(this IGraphQLClient client,
+            GraphQLRequest request, Func<TResponse> defineResponseType, CancellationToken cancellationToken = default)
+            => client.SendMutationAsync<TResponse>(request, cancellationToken);
 
-		public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
-			this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType)
-			=> client.CreateSubscriptionStream<TResponse>(request);
+        public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
+            this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType)
+            => client.CreateSubscriptionStream<TResponse>(request);
 
-		public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
-			this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<Exception> exceptionHandler)
-			=> client.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
-	}
+        public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
+            this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<Exception> exceptionHandler)
+            => client.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
+    }
 }

--- a/src/GraphQL.Client.Abstractions/GraphQLJsonSerializerExtensions.cs
+++ b/src/GraphQL.Client.Abstractions/GraphQLJsonSerializerExtensions.cs
@@ -2,32 +2,37 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 
-namespace GraphQL.Client.Abstractions {
-	public static class GraphQLJsonSerializerExtensions {
-		public static TSerializerInterface EnsureAssigned<TSerializerInterface>(this TSerializerInterface jsonSerializer) where TSerializerInterface: IGraphQLJsonSerializer {
-			// if no serializer was assigned
-			if (jsonSerializer == null) {
-				// try to find one in the assembly and assign that
-				var type = typeof(TSerializerInterface);
-				var serializerType = AppDomain.CurrentDomain
-					.GetAssemblies()
-					.SelectMany(s => s.GetTypes())
-					.FirstOrDefault(p => type.IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract);
-				if (serializerType == null)
-					throw new InvalidOperationException($"no implementation of \"{type}\" found");
+namespace GraphQL.Client.Abstractions
+{
+    public static class GraphQLJsonSerializerExtensions
+    {
+        public static TSerializerInterface EnsureAssigned<TSerializerInterface>(this TSerializerInterface jsonSerializer) where TSerializerInterface : IGraphQLJsonSerializer
+        {
+            // if no serializer was assigned
+            if (jsonSerializer == null)
+            {
+                // try to find one in the assembly and assign that
+                var type = typeof(TSerializerInterface);
+                var serializerType = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .SelectMany(s => s.GetTypes())
+                    .FirstOrDefault(p => type.IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract);
+                if (serializerType == null)
+                    throw new InvalidOperationException($"no implementation of \"{type}\" found");
 
-				jsonSerializer = (TSerializerInterface)Activator.CreateInstance(serializerType);
-			}
+                jsonSerializer = (TSerializerInterface)Activator.CreateInstance(serializerType);
+            }
 
-			return jsonSerializer;
-		}
+            return jsonSerializer;
+        }
 
-		public static TOptions New<TOptions>(this Action<TOptions> configure) =>
-			configure.AndReturn(Activator.CreateInstance<TOptions>());
+        public static TOptions New<TOptions>(this Action<TOptions> configure) =>
+            configure.AndReturn(Activator.CreateInstance<TOptions>());
 
-		public static TOptions AndReturn<TOptions>(this Action<TOptions> configure, TOptions options) {
-			configure(options);
-			return options;
-		}
-	}
+        public static TOptions AndReturn<TOptions>(this Action<TOptions> configure, TOptions options)
+        {
+            configure(options);
+            return options;
+        }
+    }
 }

--- a/src/GraphQL.Client.Abstractions/GraphQLJsonSerializerExtensions.cs
+++ b/src/GraphQL.Client.Abstractions/GraphQLJsonSerializerExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 
 namespace GraphQL.Client.Abstractions

--- a/src/GraphQL.Client.Abstractions/IGraphQLClient.cs
+++ b/src/GraphQL.Client.Abstractions/IGraphQLClient.cs
@@ -3,34 +3,36 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GraphQL.Client.Abstractions {
+namespace GraphQL.Client.Abstractions
+{
 
-	public interface IGraphQLClient : IDisposable {
+    public interface IGraphQLClient : IDisposable
+    {
 
-		Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default);
+        Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default);
 
-		Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default);
+        Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
-		/// All subscriptions made to this stream share the same hot observable.<br/>
-		/// The stream must be recreated completely after an error has occured within its logic (i.e. a <see cref="WebSocketException"/>)
-		/// </summary>
-		/// <param name="request">the GraphQL request for this subscription</param>
-		/// <returns>an observable stream for the specified subscription</returns>
-		IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request);
-		
-		/// <summary>
-		/// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
-		/// All subscriptions made to this stream share the same hot observable.<br/>
-		/// All <see cref="Exception"/>s are passed to the <paramref name="exceptionHandler"/> to be handled externally.<br/>
-		/// If the <paramref name="exceptionHandler"/> completes normally, the subscription is recreated with a new connection attempt.<br/>
-		/// Any exception thrown by <paramref name="exceptionHandler"/> will cause the sequence to fail.
-		/// </summary>
-		/// <param name="request">the GraphQL request for this subscription</param>
-		/// <param name="exceptionHandler">an external handler for all <see cref="Exception"/>s occuring within the sequence</param>
-		/// <returns>an observable stream for the specified subscription</returns>
-		IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler);
-	}
+        /// <summary>
+        /// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
+        /// All subscriptions made to this stream share the same hot observable.<br/>
+        /// The stream must be recreated completely after an error has occured within its logic (i.e. a <see cref="WebSocketException"/>)
+        /// </summary>
+        /// <param name="request">the GraphQL request for this subscription</param>
+        /// <returns>an observable stream for the specified subscription</returns>
+        IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request);
+
+        /// <summary>
+        /// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
+        /// All subscriptions made to this stream share the same hot observable.<br/>
+        /// All <see cref="Exception"/>s are passed to the <paramref name="exceptionHandler"/> to be handled externally.<br/>
+        /// If the <paramref name="exceptionHandler"/> completes normally, the subscription is recreated with a new connection attempt.<br/>
+        /// Any exception thrown by <paramref name="exceptionHandler"/> will cause the sequence to fail.
+        /// </summary>
+        /// <param name="request">the GraphQL request for this subscription</param>
+        /// <param name="exceptionHandler">an external handler for all <see cref="Exception"/>s occuring within the sequence</param>
+        /// <returns>an observable stream for the specified subscription</returns>
+        IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler);
+    }
 
 }

--- a/src/GraphQL.Client.Abstractions/IGraphQLJsonSerializer.cs
+++ b/src/GraphQL.Client.Abstractions/IGraphQLJsonSerializer.cs
@@ -2,13 +2,15 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GraphQL.Client.Abstractions {
-	public interface IGraphQLJsonSerializer {
-		string SerializeToString(GraphQLRequest request);
+namespace GraphQL.Client.Abstractions
+{
+    public interface IGraphQLJsonSerializer
+    {
+        string SerializeToString(GraphQLRequest request);
 
-		Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream,
-			CancellationToken cancellationToken);
-	}
+        Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream,
+            CancellationToken cancellationToken);
+    }
 
 
 }

--- a/src/GraphQL.Client.LocalExecution/ExecutionResultExtensions.cs
+++ b/src/GraphQL.Client.LocalExecution/ExecutionResultExtensions.cs
@@ -1,5 +1,7 @@
-﻿namespace GraphQL.Client.LocalExecution {
-	public class ExecutionResultExtensions {
-		
-	}
+namespace GraphQL.Client.LocalExecution
+{
+    public class ExecutionResultExtensions
+    {
+
+    }
 }

--- a/src/GraphQL.Client.LocalExecution/GraphQLEnumConverter.cs
+++ b/src/GraphQL.Client.LocalExecution/GraphQLEnumConverter.cs
@@ -5,27 +5,34 @@ using GraphQL.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace GraphQL.Client.LocalExecution {
-	public class GraphQLEnumConverter : StringEnumConverter {
-		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
-			if (value == null) {
-				writer.WriteNull();
-			}
-			else {
-				var enumString = ((Enum)value).ToString("G");
-				var memberName = value.GetType()
-					.GetMember(enumString, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public)
-					.FirstOrDefault()?.Name;
-				if (string.IsNullOrEmpty(memberName)) {
-					if (!AllowIntegerValues)
-						throw new JsonSerializationException($"Integer value {value} is not allowed.");
-					writer.WriteValue(value);
-				}
-				else {
-					writer.WriteValue(StringUtils.ToConstantCase(memberName));
-				}
-			}
-		}
-	}
+namespace GraphQL.Client.LocalExecution
+{
+    public class GraphQLEnumConverter : StringEnumConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                var enumString = ((Enum)value).ToString("G");
+                var memberName = value.GetType()
+                    .GetMember(enumString, BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public)
+                    .FirstOrDefault()?.Name;
+                if (string.IsNullOrEmpty(memberName))
+                {
+                    if (!AllowIntegerValues)
+                        throw new JsonSerializationException($"Integer value {value} is not allowed.");
+                    writer.WriteValue(value);
+                }
+                else
+                {
+                    writer.WriteValue(StringUtils.ToConstantCase(memberName));
+                }
+            }
+        }
+    }
 
 }

--- a/src/GraphQL.Client.LocalExecution/GraphQLLocalExecutionClient.cs
+++ b/src/GraphQL.Client.LocalExecution/GraphQLLocalExecutionClient.cs
@@ -16,102 +16,114 @@ using Newtonsoft.Json.Serialization;
 
 namespace GraphQL.Client.LocalExecution
 {
-	public static class GraphQLLocalExecutionClient {
-		public static GraphQLLocalExecutionClient<TSchema> New<TSchema>(TSchema schema) where TSchema : ISchema
-			=> new GraphQLLocalExecutionClient<TSchema>(schema);
+    public static class GraphQLLocalExecutionClient
+    {
+        public static GraphQLLocalExecutionClient<TSchema> New<TSchema>(TSchema schema) where TSchema : ISchema
+            => new GraphQLLocalExecutionClient<TSchema>(schema);
 
-		public static GraphQLLocalExecutionClient<TSchema> New<TSchema>(TSchema schema, IGraphQLJsonSerializer serializer) where TSchema : ISchema
-			=> new GraphQLLocalExecutionClient<TSchema>(schema, serializer);
-	}
-
-
-	public class GraphQLLocalExecutionClient<TSchema>: IGraphQLClient where TSchema: ISchema {
-
-	    private static readonly JsonSerializerSettings VariablesSerializerSettings = new JsonSerializerSettings {
-		    Formatting = Formatting.Indented,
-		    DateTimeZoneHandling = DateTimeZoneHandling.Local,
-		    ContractResolver = new CamelCasePropertyNamesContractResolver(),
-		    Converters = new List<JsonConverter>
-		    {
-			    new GraphQLEnumConverter()
-		    }
-	    };
-
-		public TSchema Schema { get; }
-		public IGraphQLJsonSerializer Serializer { get; }
+        public static GraphQLLocalExecutionClient<TSchema> New<TSchema>(TSchema schema, IGraphQLJsonSerializer serializer) where TSchema : ISchema
+            => new GraphQLLocalExecutionClient<TSchema>(schema, serializer);
+    }
 
 
-		private readonly DocumentExecuter documentExecuter;
+    public class GraphQLLocalExecutionClient<TSchema> : IGraphQLClient where TSchema : ISchema
+    {
 
-		public GraphQLLocalExecutionClient(TSchema schema) {
-			Serializer.EnsureAssigned();
-			Schema = schema;
-			if (!Schema.Initialized) Schema.Initialize();
-			documentExecuter = new DocumentExecuter();
-		}
+        private static readonly JsonSerializerSettings VariablesSerializerSettings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            DateTimeZoneHandling = DateTimeZoneHandling.Local,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = new List<JsonConverter>
+            {
+                new GraphQLEnumConverter()
+            }
+        };
 
-		public GraphQLLocalExecutionClient(TSchema schema, IGraphQLJsonSerializer serializer) : this(schema) {
-			Serializer = serializer;
-		}
+        public TSchema Schema { get; }
+        public IGraphQLJsonSerializer Serializer { get; }
 
-		public void Dispose() { }
 
-	    public Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
-		    => ExecuteQueryAsync<TResponse>(request, cancellationToken);
+        private readonly DocumentExecuter documentExecuter;
 
-	    public Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
-		    => ExecuteQueryAsync<TResponse>(request, cancellationToken);
+        public GraphQLLocalExecutionClient(TSchema schema)
+        {
+            Serializer.EnsureAssigned();
+            Schema = schema;
+            if (!Schema.Initialized)
+                Schema.Initialize();
+            documentExecuter = new DocumentExecuter();
+        }
 
-		public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request) {
-			return Observable.Defer(() => ExecuteSubscriptionAsync<TResponse>(request).ToObservable())
-				.Concat()
-				.Publish()
-				.RefCount();
-		}
+        public GraphQLLocalExecutionClient(TSchema schema, IGraphQLJsonSerializer serializer) : this(schema)
+        {
+            Serializer = serializer;
+        }
 
-		public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request,
-			Action<Exception> exceptionHandler)
-			=> CreateSubscriptionStream<TResponse>(request);
+        public void Dispose() { }
 
-	    #region Private Methods
+        public Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+            => ExecuteQueryAsync<TResponse>(request, cancellationToken);
 
-	    private async Task<GraphQLResponse<TResponse>> ExecuteQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken) {
-		    var executionResult = await ExecuteAsync(request, cancellationToken);
-		    return await ExecutionResultToGraphQLResponse<TResponse>(executionResult, cancellationToken);
-	    }
-	    private async Task<IObservable<GraphQLResponse<TResponse>>> ExecuteSubscriptionAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default) {
-		    var result = await ExecuteAsync(request, cancellationToken);
-		    return ((SubscriptionExecutionResult)result).Streams?.Values.SingleOrDefault()?
-			    .SelectMany(executionResult => Observable.FromAsync(token => ExecutionResultToGraphQLResponse<TResponse>(executionResult, token)));
-	    }
+        public Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+            => ExecuteQueryAsync<TResponse>(request, cancellationToken);
 
-	    private async Task<ExecutionResult> ExecuteAsync(GraphQLRequest request, CancellationToken cancellationToken = default) {
-		    var serializedRequest = Serializer.SerializeToString(request);
+        public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request)
+        {
+            return Observable.Defer(() => ExecuteSubscriptionAsync<TResponse>(request).ToObservable())
+                .Concat()
+                .Publish()
+                .RefCount();
+        }
 
-		    var deserializedRequest = JsonConvert.DeserializeObject<GraphQLRequest>(serializedRequest);
-		    var inputs = deserializedRequest.Variables != null
-			    ? (JObject.FromObject(request.Variables, JsonSerializer.Create(VariablesSerializerSettings)) as JObject)
-			    .ToInputs()
-			    : null;
+        public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request,
+            Action<Exception> exceptionHandler)
+            => CreateSubscriptionStream<TResponse>(request);
 
-		    var result = await documentExecuter.ExecuteAsync(options => {
-			    options.Schema = Schema;
-			    options.OperationName = request.OperationName;
-			    options.Query = request.Query;
-			    options.Inputs = inputs;
-			    options.CancellationToken = cancellationToken;
-		    });
+        #region Private Methods
 
-		    return result;
-	    }
+        private async Task<GraphQLResponse<TResponse>> ExecuteQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken)
+        {
+            var executionResult = await ExecuteAsync(request, cancellationToken);
+            return await ExecutionResultToGraphQLResponse<TResponse>(executionResult, cancellationToken);
+        }
+        private async Task<IObservable<GraphQLResponse<TResponse>>> ExecuteSubscriptionAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+        {
+            var result = await ExecuteAsync(request, cancellationToken);
+            return ((SubscriptionExecutionResult)result).Streams?.Values.SingleOrDefault()?
+                .SelectMany(executionResult => Observable.FromAsync(token => ExecutionResultToGraphQLResponse<TResponse>(executionResult, token)));
+        }
 
-	    private Task<GraphQLResponse<TResponse>> ExecutionResultToGraphQLResponse<TResponse>(ExecutionResult executionResult, CancellationToken cancellationToken = default) {
-		    // serialize result into utf8 byte stream
-		    var resultStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(executionResult, VariablesSerializerSettings)));
-		    // deserialize using the provided serializer
-		    return Serializer.DeserializeFromUtf8StreamAsync<TResponse>(resultStream, cancellationToken);
-	    }
+        private async Task<ExecutionResult> ExecuteAsync(GraphQLRequest request, CancellationToken cancellationToken = default)
+        {
+            var serializedRequest = Serializer.SerializeToString(request);
 
-	    #endregion
-	}
+            var deserializedRequest = JsonConvert.DeserializeObject<GraphQLRequest>(serializedRequest);
+            var inputs = deserializedRequest.Variables != null
+                ? (JObject.FromObject(request.Variables, JsonSerializer.Create(VariablesSerializerSettings)) as JObject)
+                .ToInputs()
+                : null;
+
+            var result = await documentExecuter.ExecuteAsync(options =>
+            {
+                options.Schema = Schema;
+                options.OperationName = request.OperationName;
+                options.Query = request.Query;
+                options.Inputs = inputs;
+                options.CancellationToken = cancellationToken;
+            });
+
+            return result;
+        }
+
+        private Task<GraphQLResponse<TResponse>> ExecutionResultToGraphQLResponse<TResponse>(ExecutionResult executionResult, CancellationToken cancellationToken = default)
+        {
+            // serialize result into utf8 byte stream
+            var resultStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(executionResult, VariablesSerializerSettings)));
+            // deserialize using the provided serializer
+            return Serializer.DeserializeFromUtf8StreamAsync<TResponse>(resultStream, cancellationToken);
+        }
+
+        #endregion
+    }
 }

--- a/src/GraphQL.Client.Serializer.Newtonsoft/GraphQLExtensionsConverter.cs
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/GraphQLExtensionsConverter.cs
@@ -6,65 +6,79 @@ using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace GraphQL.Client.Serializer.Newtonsoft {
-	public class GraphQLExtensionsConverter: JsonConverter<GraphQLExtensionsType> {
-		public override void WriteJson(JsonWriter writer, GraphQLExtensionsType value, JsonSerializer serializer) {
-			throw new NotImplementedException(
-				"This converter currently is only intended to be used to read a JSON object into a strongly-typed representation.");
-		}
+namespace GraphQL.Client.Serializer.Newtonsoft
+{
+    public class GraphQLExtensionsConverter : JsonConverter<GraphQLExtensionsType>
+    {
+        public override void WriteJson(JsonWriter writer, GraphQLExtensionsType value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException(
+                "This converter currently is only intended to be used to read a JSON object into a strongly-typed representation.");
+        }
 
-		public override GraphQLExtensionsType ReadJson(JsonReader reader, Type objectType, GraphQLExtensionsType existingValue,
-			bool hasExistingValue, JsonSerializer serializer) {
-			var rootToken = JToken.ReadFrom(reader);
-			if (rootToken is JObject) {
-				return ReadDictionary<GraphQLExtensionsType>(rootToken);
-			}
-			else
-				throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
-		}
+        public override GraphQLExtensionsType ReadJson(JsonReader reader, Type objectType, GraphQLExtensionsType existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            var rootToken = JToken.ReadFrom(reader);
+            if (rootToken is JObject)
+            {
+                return ReadDictionary<GraphQLExtensionsType>(rootToken);
+            }
+            else
+                throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
+        }
 
-		private object ReadToken(JToken? token) {
-			return token.Type switch {
-				JTokenType.Undefined => null,
-				JTokenType.None => null,
-				JTokenType.Null => null,
-				JTokenType.Object => ReadDictionary<Dictionary<string, object>>(token),
-				JTokenType.Array => ReadArray(token),
-				JTokenType.Integer => token.Value<int>(),
-				JTokenType.Float => token.Value<double>(),
-				JTokenType.Raw => token.Value<string>(),
-				JTokenType.String => token.Value<string>(),
-				JTokenType.Uri => token.Value<string>(),
-				JTokenType.Boolean => token.Value<bool>(),
-				JTokenType.Date => token.Value<DateTime>(),
-				JTokenType.Bytes => token.Value<byte[]>(),
-				JTokenType.Guid => token.Value<Guid>(),
-				JTokenType.TimeSpan => token.Value<TimeSpan>(),
-				JTokenType.Constructor => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON constructor"),
-				JTokenType.Property => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON property"),
-				JTokenType.Comment => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON comment"),
-				_ => throw new ArgumentOutOfRangeException(nameof(token.Type))
-			};
-		}
+        private object ReadToken(JToken? token)
+        {
+            return token.Type switch
+            {
+                JTokenType.Undefined => null,
+                JTokenType.None => null,
+                JTokenType.Null => null,
+                JTokenType.Object => ReadDictionary<Dictionary<string, object>>(token),
+                JTokenType.Array => ReadArray(token),
+                JTokenType.Integer => token.Value<int>(),
+                JTokenType.Float => token.Value<double>(),
+                JTokenType.Raw => token.Value<string>(),
+                JTokenType.String => token.Value<string>(),
+                JTokenType.Uri => token.Value<string>(),
+                JTokenType.Boolean => token.Value<bool>(),
+                JTokenType.Date => token.Value<DateTime>(),
+                JTokenType.Bytes => token.Value<byte[]>(),
+                JTokenType.Guid => token.Value<Guid>(),
+                JTokenType.TimeSpan => token.Value<TimeSpan>(),
+                JTokenType.Constructor => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON constructor"),
+                JTokenType.Property => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON property"),
+                JTokenType.Comment => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON comment"),
+                _ => throw new ArgumentOutOfRangeException(nameof(token.Type))
+            };
+        }
 
-		private TDictionary ReadDictionary<TDictionary>(JToken element) where TDictionary : Dictionary<string, object> {
-			var result = Activator.CreateInstance<TDictionary>();
-			foreach (var property in ((JObject)element).Properties()) {
-				if (IsUnsupportedJTokenType(property.Value.Type)) continue;
-				result[property.Name] = ReadToken(property.Value);
-			}
-			return result;
-		}
+        private TDictionary ReadDictionary<TDictionary>(JToken element) where TDictionary : Dictionary<string, object>
+        {
+            var result = Activator.CreateInstance<TDictionary>();
+            foreach (var property in ((JObject)element).Properties())
+            {
+                if (IsUnsupportedJTokenType(property.Value.Type))
+                    continue;
+                result[property.Name] = ReadToken(property.Value);
+            }
+            return result;
+        }
 
-		private IEnumerable<object> ReadArray(JToken element) {
-			foreach (var item in element.Values()) {
-				if (IsUnsupportedJTokenType(item.Type)) continue;
-				yield return ReadToken(item);
-			}
-		}
+        private IEnumerable<object> ReadArray(JToken element)
+        {
+            foreach (var item in element.Values())
+            {
+                if (IsUnsupportedJTokenType(item.Type))
+                    continue;
+                yield return ReadToken(item);
+            }
+        }
 
-		private bool IsUnsupportedJTokenType(JTokenType type) {
-			return type == JTokenType.Constructor || type == JTokenType.Property || type == JTokenType.Comment;
-		}
-	}
+        private bool IsUnsupportedJTokenType(JTokenType type)
+        {
+            return type == JTokenType.Constructor || type == JTokenType.Property || type == JTokenType.Comment;
+        }
+    }
 }

--- a/src/GraphQL.Client.Serializer.Newtonsoft/GraphQLExtensionsConverter.cs
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/GraphQLExtensionsConverter.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -10,11 +7,9 @@ namespace GraphQL.Client.Serializer.Newtonsoft
 {
     public class GraphQLExtensionsConverter : JsonConverter<GraphQLExtensionsType>
     {
-        public override void WriteJson(JsonWriter writer, GraphQLExtensionsType value, JsonSerializer serializer)
-        {
+        public override void WriteJson(JsonWriter writer, GraphQLExtensionsType value, JsonSerializer serializer) =>
             throw new NotImplementedException(
                 "This converter currently is only intended to be used to read a JSON object into a strongly-typed representation.");
-        }
 
         public override GraphQLExtensionsType ReadJson(JsonReader reader, Type objectType, GraphQLExtensionsType existingValue,
             bool hasExistingValue, JsonSerializer serializer)
@@ -28,9 +23,8 @@ namespace GraphQL.Client.Serializer.Newtonsoft
                 throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
         }
 
-        private object ReadToken(JToken? token)
-        {
-            return token.Type switch
+        private object ReadToken(JToken? token) =>
+            token.Type switch
             {
                 JTokenType.Undefined => null,
                 JTokenType.None => null,
@@ -52,7 +46,6 @@ namespace GraphQL.Client.Serializer.Newtonsoft
                 JTokenType.Comment => throw new ArgumentOutOfRangeException(nameof(token.Type), "cannot deserialize a JSON comment"),
                 _ => throw new ArgumentOutOfRangeException(nameof(token.Type))
             };
-        }
 
         private TDictionary ReadDictionary<TDictionary>(JToken element) where TDictionary : Dictionary<string, object>
         {
@@ -76,9 +69,6 @@ namespace GraphQL.Client.Serializer.Newtonsoft
             }
         }
 
-        private bool IsUnsupportedJTokenType(JTokenType type)
-        {
-            return type == JTokenType.Constructor || type == JTokenType.Property || type == JTokenType.Comment;
-        }
+        private bool IsUnsupportedJTokenType(JTokenType type) => type == JTokenType.Constructor || type == JTokenType.Property || type == JTokenType.Comment;
     }
 }

--- a/src/GraphQL.Client.Serializer.Newtonsoft/NewtonsoftJsonSerializer.cs
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/NewtonsoftJsonSerializer.cs
@@ -30,45 +30,31 @@ namespace GraphQL.Client.Serializer.Newtonsoft
             ConfigureMandatorySerializerOptions();
         }
 
-        private void ConfigureMandatorySerializerOptions()
-        {
-            // deserialize extensions to Dictionary<string, object>
-            JsonSerializerSettings.Converters.Insert(0, new GraphQLExtensionsConverter());
-        }
+        // deserialize extensions to Dictionary<string, object>
+        private void ConfigureMandatorySerializerOptions() => JsonSerializerSettings.Converters.Insert(0, new GraphQLExtensionsConverter());
 
-        public string SerializeToString(GraphQL.GraphQLRequest request)
-        {
-            return JsonConvert.SerializeObject(request, JsonSerializerSettings);
-        }
+        public string SerializeToString(GraphQLRequest request) => JsonConvert.SerializeObject(request, JsonSerializerSettings);
 
-        public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request)
+        public byte[] SerializeToBytes(GraphQLWebSocketRequest request)
         {
             var json = JsonConvert.SerializeObject(request, JsonSerializerSettings);
             return Encoding.UTF8.GetBytes(json);
         }
 
-        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream)
-        {
-            return DeserializeFromUtf8Stream<WebsocketMessageWrapper>(stream);
-        }
+        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream) => DeserializeFromUtf8Stream<WebsocketMessageWrapper>(stream);
 
-        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes)
-        {
-            return JsonConvert.DeserializeObject<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(Encoding.UTF8.GetString(bytes),
+        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes) =>
+            JsonConvert.DeserializeObject<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(Encoding.UTF8.GetString(bytes),
                 JsonSerializerSettings);
-        }
 
-        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken)
-        {
-            return DeserializeFromUtf8Stream<GraphQLResponse<TResponse>>(stream);
-        }
+        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken) => DeserializeFromUtf8Stream<GraphQLResponse<TResponse>>(stream);
 
 
         private Task<T> DeserializeFromUtf8Stream<T>(Stream stream)
         {
-            using StreamReader sr = new StreamReader(stream);
+            using var sr = new StreamReader(stream);
             using JsonReader reader = new JsonTextReader(sr);
-            JsonSerializer serializer = JsonSerializer.Create(JsonSerializerSettings);
+            var serializer = JsonSerializer.Create(JsonSerializerSettings);
             return Task.FromResult(serializer.Deserialize<T>(reader));
         }
 

--- a/src/GraphQL.Client.Serializer.Newtonsoft/NewtonsoftJsonSerializer.cs
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/NewtonsoftJsonSerializer.cs
@@ -10,58 +10,67 @@ using Newtonsoft.Json.Serialization;
 
 namespace GraphQL.Client.Serializer.Newtonsoft
 {
-    public class NewtonsoftJsonSerializer: IGraphQLWebsocketJsonSerializer
+    public class NewtonsoftJsonSerializer : IGraphQLWebsocketJsonSerializer
     {
-		public static JsonSerializerSettings DefaultJsonSerializerSettings => new JsonSerializerSettings {
-			ContractResolver = new CamelCasePropertyNamesContractResolver { IgnoreIsSpecifiedMembers = true },
-			MissingMemberHandling = MissingMemberHandling.Ignore
-		};
+        public static JsonSerializerSettings DefaultJsonSerializerSettings => new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver { IgnoreIsSpecifiedMembers = true },
+            MissingMemberHandling = MissingMemberHandling.Ignore
+        };
 
-		public JsonSerializerSettings JsonSerializerSettings { get; }
+        public JsonSerializerSettings JsonSerializerSettings { get; }
 
-	    public NewtonsoftJsonSerializer() : this(DefaultJsonSerializerSettings) { }
+        public NewtonsoftJsonSerializer() : this(DefaultJsonSerializerSettings) { }
 
-		public NewtonsoftJsonSerializer(Action<JsonSerializerSettings> configure) : this(configure.AndReturn(DefaultJsonSerializerSettings)) { }
+        public NewtonsoftJsonSerializer(Action<JsonSerializerSettings> configure) : this(configure.AndReturn(DefaultJsonSerializerSettings)) { }
 
-		public NewtonsoftJsonSerializer(JsonSerializerSettings jsonSerializerSettings) {
-		    JsonSerializerSettings = jsonSerializerSettings;
-		    ConfigureMandatorySerializerOptions();
-		}
+        public NewtonsoftJsonSerializer(JsonSerializerSettings jsonSerializerSettings)
+        {
+            JsonSerializerSettings = jsonSerializerSettings;
+            ConfigureMandatorySerializerOptions();
+        }
 
-		private void ConfigureMandatorySerializerOptions() {
-			// deserialize extensions to Dictionary<string, object>
-			JsonSerializerSettings.Converters.Insert(0, new GraphQLExtensionsConverter());
-		}
+        private void ConfigureMandatorySerializerOptions()
+        {
+            // deserialize extensions to Dictionary<string, object>
+            JsonSerializerSettings.Converters.Insert(0, new GraphQLExtensionsConverter());
+        }
 
-		public string SerializeToString(GraphQL.GraphQLRequest request) {
-		    return JsonConvert.SerializeObject(request, JsonSerializerSettings);
-		}
+        public string SerializeToString(GraphQL.GraphQLRequest request)
+        {
+            return JsonConvert.SerializeObject(request, JsonSerializerSettings);
+        }
 
-		public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request) {
-			var json = JsonConvert.SerializeObject(request, JsonSerializerSettings);
-			return Encoding.UTF8.GetBytes(json);
-		}
+        public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request)
+        {
+            var json = JsonConvert.SerializeObject(request, JsonSerializerSettings);
+            return Encoding.UTF8.GetBytes(json);
+        }
 
-		public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream) {
-			return DeserializeFromUtf8Stream<WebsocketMessageWrapper>(stream);
-		}
+        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream)
+        {
+            return DeserializeFromUtf8Stream<WebsocketMessageWrapper>(stream);
+        }
 
-		public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes) {
-			return JsonConvert.DeserializeObject<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(Encoding.UTF8.GetString(bytes),
-				JsonSerializerSettings);
-		}
+        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes)
+        {
+            return JsonConvert.DeserializeObject<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(Encoding.UTF8.GetString(bytes),
+                JsonSerializerSettings);
+        }
 
-		public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken) {
-			return DeserializeFromUtf8Stream<GraphQLResponse<TResponse>>(stream);
-		}
+        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken)
+        {
+            return DeserializeFromUtf8Stream<GraphQLResponse<TResponse>>(stream);
+        }
 
 
-		private Task<T> DeserializeFromUtf8Stream<T>(Stream stream) {
-			using StreamReader sr = new StreamReader(stream);
-			using JsonReader reader = new JsonTextReader(sr);
-			JsonSerializer serializer = JsonSerializer.Create(JsonSerializerSettings);
-			return Task.FromResult(serializer.Deserialize<T>(reader));
-		}
+        private Task<T> DeserializeFromUtf8Stream<T>(Stream stream)
+        {
+            using StreamReader sr = new StreamReader(stream);
+            using JsonReader reader = new JsonTextReader(sr);
+            JsonSerializer serializer = JsonSerializer.Create(JsonSerializerSettings);
+            return Task.FromResult(serializer.Deserialize<T>(reader));
+        }
 
-	}
+    }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/GraphQLExtensionsConverter.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/GraphQLExtensionsConverter.cs
@@ -5,69 +5,78 @@ using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace GraphQL.Client.Serializer.SystemTextJson {
-	/// <summary>
-	/// A custom JsonConverter for reading the extension fields of <see cref="GraphQLResponse{T}"/> and <see cref="GraphQLError"/>.
-	/// </summary>
-	/// <remarks>
-	/// Taken and modified from GraphQL.SystemTextJson.ObjectDictionaryConverter (GraphQL.NET)
-	/// </remarks>
-	public class GraphQLExtensionsConverter : JsonConverter<GraphQLExtensionsType> {
-		public override GraphQLExtensionsType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-			using var doc = JsonDocument.ParseValue(ref reader);
+namespace GraphQL.Client.Serializer.SystemTextJson
+{
+    /// <summary>
+    /// A custom JsonConverter for reading the extension fields of <see cref="GraphQLResponse{T}"/> and <see cref="GraphQLError"/>.
+    /// </summary>
+    /// <remarks>
+    /// Taken and modified from GraphQL.SystemTextJson.ObjectDictionaryConverter (GraphQL.NET)
+    /// </remarks>
+    public class GraphQLExtensionsConverter : JsonConverter<GraphQLExtensionsType>
+    {
+        public override GraphQLExtensionsType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
 
-			if (doc?.RootElement == null || doc?.RootElement.ValueKind != JsonValueKind.Object) {
-				throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
-			}
+            if (doc?.RootElement == null || doc?.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new ArgumentException("This converter can only parse when the root element is a JSON Object.");
+            }
 
-			return ReadDictionary<GraphQLExtensionsType>(doc.RootElement);
-		}
+            return ReadDictionary<GraphQLExtensionsType>(doc.RootElement);
+        }
 
-		public override void Write(Utf8JsonWriter writer, GraphQLExtensionsType value, JsonSerializerOptions options)
-			=> throw new NotImplementedException(
-				"This converter currently is only intended to be used to read a JSON object into a strongly-typed representation.");
+        public override void Write(Utf8JsonWriter writer, GraphQLExtensionsType value, JsonSerializerOptions options)
+            => throw new NotImplementedException(
+                "This converter currently is only intended to be used to read a JSON object into a strongly-typed representation.");
 
-		private TDictionary ReadDictionary<TDictionary>(JsonElement element) where TDictionary: Dictionary<string, object> {
-			var result = Activator.CreateInstance<TDictionary>();
-			foreach (var property in element.EnumerateObject()) {
-				result[property.Name] = ReadValue(property.Value);
-			}
-			return result;
-		}
+        private TDictionary ReadDictionary<TDictionary>(JsonElement element) where TDictionary : Dictionary<string, object>
+        {
+            var result = Activator.CreateInstance<TDictionary>();
+            foreach (var property in element.EnumerateObject())
+            {
+                result[property.Name] = ReadValue(property.Value);
+            }
+            return result;
+        }
 
-		private IEnumerable<object> ReadArray(JsonElement value) {
-			foreach (var item in value.EnumerateArray()) {
-				yield return ReadValue(item);
-			}
-		}
+        private IEnumerable<object> ReadArray(JsonElement value)
+        {
+            foreach (var item in value.EnumerateArray())
+            {
+                yield return ReadValue(item);
+            }
+        }
 
-		private object ReadValue(JsonElement value)
-			=> value.ValueKind switch
-			{
-				JsonValueKind.Array => ReadArray(value).ToList(),
-				JsonValueKind.Object => ReadDictionary<Dictionary<string, object>>(value),
-				JsonValueKind.Number => ReadNumber(value),
-				JsonValueKind.True => true,
-				JsonValueKind.False => false,
-				JsonValueKind.String => value.GetString(),
-				JsonValueKind.Null => null,
-				JsonValueKind.Undefined => null,
-				_ => throw new InvalidOperationException($"Unexpected value kind: {value.ValueKind}")
-			};
+        private object ReadValue(JsonElement value)
+            => value.ValueKind switch
+            {
+                JsonValueKind.Array => ReadArray(value).ToList(),
+                JsonValueKind.Object => ReadDictionary<Dictionary<string, object>>(value),
+                JsonValueKind.Number => ReadNumber(value),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Null => null,
+                JsonValueKind.Undefined => null,
+                _ => throw new InvalidOperationException($"Unexpected value kind: {value.ValueKind}")
+            };
 
-		private object ReadNumber(JsonElement value) {
-			if (value.TryGetInt32(out var i))
-				return i;
-			else if (value.TryGetInt64(out var l))
-				return l;
-			else if (BigInteger.TryParse(value.GetRawText(), out var bi))
-				return bi;
-			else if (value.TryGetDouble(out var d))
-				return d;
-			else if (value.TryGetDecimal(out var dd))
-				return dd;
+        private object ReadNumber(JsonElement value)
+        {
+            if (value.TryGetInt32(out var i))
+                return i;
+            else if (value.TryGetInt64(out var l))
+                return l;
+            else if (BigInteger.TryParse(value.GetRawText(), out var bi))
+                return bi;
+            else if (value.TryGetDouble(out var d))
+                return d;
+            else if (value.TryGetDecimal(out var dd))
+                return dd;
 
-			throw new NotImplementedException($"Unexpected Number value. Raw text was: {value.GetRawText()}");
-		}
-	}
+            throw new NotImplementedException($"Unexpected Number value. Raw text was: {value.GetRawText()}");
+        }
+    }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/ImmutableConverter.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/ImmutableConverter.cs
@@ -6,161 +6,194 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace GraphQL.Client.Serializer.SystemTextJson {
+namespace GraphQL.Client.Serializer.SystemTextJson
+{
 
-	/// <summary>
-	/// class for converting immutable objects, derived from https://github.com/manne/obviously/blob/master/src/system.text.json/Core/ImmutableConverter.cs
-	/// </summary>
-	public class ImmutableConverter : JsonConverter<object> {
-		public override bool CanConvert(Type typeToConvert) {
-			bool result;
-			var constructors = typeToConvert.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-			if (constructors.Length != 1) {
-				result = false;
-			}
-			else {
-				var constructor = constructors[0];
-				var parameters = constructor.GetParameters();
-				var hasParameters = parameters.Length > 0;
-				if (hasParameters) {
-					var properties = typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-					result = true;
-					foreach (var parameter in parameters) {
-						var hasMatchingProperty = properties.Any(p =>
-							NameOfPropertyAndParameter.Matches(p.Name, parameter.Name, typeToConvert.IsAnonymous()));
-						if (!hasMatchingProperty) {
-							result = false;
-							break;
-						}
-					}
-				}
-				else {
-					result = false;
-				}
-			}
+    /// <summary>
+    /// class for converting immutable objects, derived from https://github.com/manne/obviously/blob/master/src/system.text.json/Core/ImmutableConverter.cs
+    /// </summary>
+    public class ImmutableConverter : JsonConverter<object>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            bool result;
+            var constructors = typeToConvert.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            if (constructors.Length != 1)
+            {
+                result = false;
+            }
+            else
+            {
+                var constructor = constructors[0];
+                var parameters = constructor.GetParameters();
+                var hasParameters = parameters.Length > 0;
+                if (hasParameters)
+                {
+                    var properties = typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    result = true;
+                    foreach (var parameter in parameters)
+                    {
+                        var hasMatchingProperty = properties.Any(p =>
+                            NameOfPropertyAndParameter.Matches(p.Name, parameter.Name, typeToConvert.IsAnonymous()));
+                        if (!hasMatchingProperty)
+                        {
+                            result = false;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    result = false;
+                }
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-			var valueOfProperty = new Dictionary<PropertyInfo, object>();
-			var namedPropertiesMapping = GetNamedProperties(options, GetProperties(typeToConvert));
-			reader.Read();
-			while (true) {
-				if (reader.TokenType != JsonTokenType.PropertyName && reader.TokenType != JsonTokenType.String) {
-					break;
-				}
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var valueOfProperty = new Dictionary<PropertyInfo, object>();
+            var namedPropertiesMapping = GetNamedProperties(options, GetProperties(typeToConvert));
+            reader.Read();
+            while (true)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName && reader.TokenType != JsonTokenType.String)
+                {
+                    break;
+                }
 
-				var jsonPropName = reader.GetString();
-				var normalizedPropName = ConvertAndNormalizeName(jsonPropName, options);
-				if (!namedPropertiesMapping.TryGetValue(normalizedPropName, out var obProp)) {
-					reader.Read();
-				}
-				else {
-					var value = JsonSerializer.Deserialize(ref reader, obProp.PropertyType, options);
-					reader.Read();
-					valueOfProperty[obProp] = value;
-				}
-			}
+                var jsonPropName = reader.GetString();
+                var normalizedPropName = ConvertAndNormalizeName(jsonPropName, options);
+                if (!namedPropertiesMapping.TryGetValue(normalizedPropName, out var obProp))
+                {
+                    reader.Read();
+                }
+                else
+                {
+                    var value = JsonSerializer.Deserialize(ref reader, obProp.PropertyType, options);
+                    reader.Read();
+                    valueOfProperty[obProp] = value;
+                }
+            }
 
-			var ctor = typeToConvert.GetConstructors(BindingFlags.Public | BindingFlags.Instance).First();
-			var parameters = ctor.GetParameters();
-			var parameterValues = new object[parameters.Length];
-			for (var index = 0; index < parameters.Length; index++) {
-				var parameterInfo = parameters[index];
-				var value = valueOfProperty.First(prop =>
-					NameOfPropertyAndParameter.Matches(prop.Key.Name, parameterInfo.Name, typeToConvert.IsAnonymous())).Value;
+            var ctor = typeToConvert.GetConstructors(BindingFlags.Public | BindingFlags.Instance).First();
+            var parameters = ctor.GetParameters();
+            var parameterValues = new object[parameters.Length];
+            for (var index = 0; index < parameters.Length; index++)
+            {
+                var parameterInfo = parameters[index];
+                var value = valueOfProperty.First(prop =>
+                    NameOfPropertyAndParameter.Matches(prop.Key.Name, parameterInfo.Name, typeToConvert.IsAnonymous())).Value;
 
-				parameterValues[index] = value;
-			}
+                parameterValues[index] = value;
+            }
 
-			var instance = ctor.Invoke(parameterValues);
-			return instance;
-		}
+            var instance = ctor.Invoke(parameterValues);
+            return instance;
+        }
 
-		public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options) {
-			var strippedOptions = new JsonSerializerOptions {
-				AllowTrailingCommas = options.AllowTrailingCommas,
-				DefaultBufferSize = options.DefaultBufferSize,
-				DictionaryKeyPolicy = options.DictionaryKeyPolicy,
-				Encoder = options.Encoder,
-				IgnoreNullValues = options.IgnoreNullValues,
-				IgnoreReadOnlyProperties = options.IgnoreReadOnlyProperties,
-				MaxDepth = options.MaxDepth,
-				PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive,
-				PropertyNamingPolicy = options.PropertyNamingPolicy,
-				ReadCommentHandling = options.ReadCommentHandling,
-				WriteIndented = options.WriteIndented
-			};
-			foreach (var converter in options.Converters) {
-				if (!(converter is ImmutableConverter))
-					strippedOptions.Converters.Add(converter);
-			}
-			JsonSerializer.Serialize(writer, value, strippedOptions);
-		}
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            var strippedOptions = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = options.AllowTrailingCommas,
+                DefaultBufferSize = options.DefaultBufferSize,
+                DictionaryKeyPolicy = options.DictionaryKeyPolicy,
+                Encoder = options.Encoder,
+                IgnoreNullValues = options.IgnoreNullValues,
+                IgnoreReadOnlyProperties = options.IgnoreReadOnlyProperties,
+                MaxDepth = options.MaxDepth,
+                PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive,
+                PropertyNamingPolicy = options.PropertyNamingPolicy,
+                ReadCommentHandling = options.ReadCommentHandling,
+                WriteIndented = options.WriteIndented
+            };
+            foreach (var converter in options.Converters)
+            {
+                if (!(converter is ImmutableConverter))
+                    strippedOptions.Converters.Add(converter);
+            }
+            JsonSerializer.Serialize(writer, value, strippedOptions);
+        }
 
-		private static PropertyInfo[] GetProperties(IReflect typeToConvert) {
-			return typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-		}
+        private static PropertyInfo[] GetProperties(IReflect typeToConvert)
+        {
+            return typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        }
 
-		private static IReadOnlyDictionary<string, PropertyInfo> GetNamedProperties(JsonSerializerOptions options, IEnumerable<PropertyInfo> properties) {
-			var result = new Dictionary<string, PropertyInfo>();
-			foreach (var property in properties) {
-				string name;
-				var nameAttribute = property.GetCustomAttribute<JsonPropertyNameAttribute>();
-				if (nameAttribute != null) {
-					name = nameAttribute.Name;
-				}
-				else {
-					name = options.PropertyNamingPolicy?.ConvertName(property.Name) ?? property.Name;
-				}
+        private static IReadOnlyDictionary<string, PropertyInfo> GetNamedProperties(JsonSerializerOptions options, IEnumerable<PropertyInfo> properties)
+        {
+            var result = new Dictionary<string, PropertyInfo>();
+            foreach (var property in properties)
+            {
+                string name;
+                var nameAttribute = property.GetCustomAttribute<JsonPropertyNameAttribute>();
+                if (nameAttribute != null)
+                {
+                    name = nameAttribute.Name;
+                }
+                else
+                {
+                    name = options.PropertyNamingPolicy?.ConvertName(property.Name) ?? property.Name;
+                }
 
-				var normalizedName = NormalizeName(name, options);
-				result.Add(normalizedName, property);
-			}
+                var normalizedName = NormalizeName(name, options);
+                result.Add(normalizedName, property);
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		private static string ConvertAndNormalizeName(string name, JsonSerializerOptions options) {
-			var convertedName = options.PropertyNamingPolicy?.ConvertName(name) ?? name;
-			return options.PropertyNameCaseInsensitive ? convertedName.ToLowerInvariant() : convertedName;
-		}
+        private static string ConvertAndNormalizeName(string name, JsonSerializerOptions options)
+        {
+            var convertedName = options.PropertyNamingPolicy?.ConvertName(name) ?? name;
+            return options.PropertyNameCaseInsensitive ? convertedName.ToLowerInvariant() : convertedName;
+        }
 
-		private static string NormalizeName(string name, JsonSerializerOptions options) {
-			return options.PropertyNameCaseInsensitive ? name.ToLowerInvariant() : name;
-		}
-	}
+        private static string NormalizeName(string name, JsonSerializerOptions options)
+        {
+            return options.PropertyNameCaseInsensitive ? name.ToLowerInvariant() : name;
+        }
+    }
 
-	internal static class NameOfPropertyAndParameter {
-		public static bool Matches(string propertyName, string parameterName, bool anonymousType) {
-			if (propertyName is null && parameterName is null) {
-				return true;
-			}
+    internal static class NameOfPropertyAndParameter
+    {
+        public static bool Matches(string propertyName, string parameterName, bool anonymousType)
+        {
+            if (propertyName is null && parameterName is null)
+            {
+                return true;
+            }
 
-			if (propertyName is null || parameterName is null) {
-				return false;
-			}
+            if (propertyName is null || parameterName is null)
+            {
+                return false;
+            }
 
-			if (anonymousType) {
-				return propertyName.Equals(parameterName, StringComparison.Ordinal);
-			}
-			else {
-				var xRight = propertyName.AsSpan(1);
-				var yRight = parameterName.AsSpan(1);
-				return char.ToLowerInvariant(propertyName[0]).CompareTo(parameterName[0]) == 0 && xRight.Equals(yRight, StringComparison.Ordinal);
-			}
-		}
-	}
+            if (anonymousType)
+            {
+                return propertyName.Equals(parameterName, StringComparison.Ordinal);
+            }
+            else
+            {
+                var xRight = propertyName.AsSpan(1);
+                var yRight = parameterName.AsSpan(1);
+                return char.ToLowerInvariant(propertyName[0]).CompareTo(parameterName[0]) == 0 && xRight.Equals(yRight, StringComparison.Ordinal);
+            }
+        }
+    }
 
-	internal static class TypeExtensions {
-		// copied from https://github.com/dahomey-technologies/Dahomey.Json/blob/master/src/Dahomey.Json/Util/TypeExtensions.cs
-		public static bool IsAnonymous(this Type type) {
-			return type.Namespace == null
-			       && type.IsSealed
-			       && type.BaseType == typeof(object)
-			       && !type.IsPublic
-			       && type.IsDefined(typeof(CompilerGeneratedAttribute), false);
-		}
-	}
+    internal static class TypeExtensions
+    {
+        // copied from https://github.com/dahomey-technologies/Dahomey.Json/blob/master/src/Dahomey.Json/Util/TypeExtensions.cs
+        public static bool IsAnonymous(this Type type)
+        {
+            return type.Namespace == null
+                   && type.IsSealed
+                   && type.BaseType == typeof(object)
+                   && !type.IsPublic
+                   && type.IsDefined(typeof(CompilerGeneratedAttribute), false);
+        }
+    }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/ImmutableConverter.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/ImmutableConverter.cs
@@ -117,10 +117,7 @@ namespace GraphQL.Client.Serializer.SystemTextJson
             JsonSerializer.Serialize(writer, value, strippedOptions);
         }
 
-        private static PropertyInfo[] GetProperties(IReflect typeToConvert)
-        {
-            return typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        }
+        private static PropertyInfo[] GetProperties(IReflect typeToConvert) => typeToConvert.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
         private static IReadOnlyDictionary<string, PropertyInfo> GetNamedProperties(JsonSerializerOptions options, IEnumerable<PropertyInfo> properties)
         {
@@ -151,10 +148,7 @@ namespace GraphQL.Client.Serializer.SystemTextJson
             return options.PropertyNameCaseInsensitive ? convertedName.ToLowerInvariant() : convertedName;
         }
 
-        private static string NormalizeName(string name, JsonSerializerOptions options)
-        {
-            return options.PropertyNameCaseInsensitive ? name.ToLowerInvariant() : name;
-        }
+        private static string NormalizeName(string name, JsonSerializerOptions options) => options.PropertyNameCaseInsensitive ? name.ToLowerInvariant() : name;
     }
 
     internal static class NameOfPropertyAndParameter
@@ -187,13 +181,11 @@ namespace GraphQL.Client.Serializer.SystemTextJson
     internal static class TypeExtensions
     {
         // copied from https://github.com/dahomey-technologies/Dahomey.Json/blob/master/src/Dahomey.Json/Util/TypeExtensions.cs
-        public static bool IsAnonymous(this Type type)
-        {
-            return type.Namespace == null
-                   && type.IsSealed
-                   && type.BaseType == typeof(object)
-                   && !type.IsPublic
-                   && type.IsDefined(typeof(CompilerGeneratedAttribute), false);
-        }
+        public static bool IsAnonymous(this Type type) =>
+            type.Namespace == null
+            && type.IsSealed
+            && type.BaseType == typeof(object)
+            && !type.IsPublic
+            && type.IsDefined(typeof(CompilerGeneratedAttribute), false);
     }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/JsonSerializerOptionsExtensions.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/JsonSerializerOptionsExtensions.cs
@@ -1,11 +1,14 @@
 using System.Text.Json;
 
-namespace GraphQL.Client.Serializer.SystemTextJson {
-	public static class JsonSerializerOptionsExtensions {
-		public static JsonSerializerOptions SetupImmutableConverter(
-			this JsonSerializerOptions options) {
-			options.Converters.Add(new ImmutableConverter());
-			return options;
-		}
-	}
+namespace GraphQL.Client.Serializer.SystemTextJson
+{
+    public static class JsonSerializerOptionsExtensions
+    {
+        public static JsonSerializerOptions SetupImmutableConverter(
+            this JsonSerializerOptions options)
+        {
+            options.Converters.Add(new ImmutableConverter());
+            return options;
+        }
+    }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
@@ -8,50 +8,58 @@ using GraphQL.Client.Abstractions.Websocket;
 
 namespace GraphQL.Client.Serializer.SystemTextJson
 {
-    public class SystemTextJsonSerializer: IGraphQLWebsocketJsonSerializer
+    public class SystemTextJsonSerializer : IGraphQLWebsocketJsonSerializer
     {
-	    public static JsonSerializerOptions DefaultJsonSerializerOptions => new JsonSerializerOptions {
-		    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-	    }.SetupImmutableConverter();
-		
-		public JsonSerializerOptions Options { get; }
+        public static JsonSerializerOptions DefaultJsonSerializerOptions => new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        }.SetupImmutableConverter();
 
-	    public SystemTextJsonSerializer() : this(DefaultJsonSerializerOptions) { }
+        public JsonSerializerOptions Options { get; }
 
-	    public SystemTextJsonSerializer(Action<JsonSerializerOptions> configure) : this(configure.AndReturn(DefaultJsonSerializerOptions)) { }
+        public SystemTextJsonSerializer() : this(DefaultJsonSerializerOptions) { }
 
-		public SystemTextJsonSerializer(JsonSerializerOptions options) {
-		    Options = options;
-		    ConfigureMandatorySerializerOptions();
-		}
+        public SystemTextJsonSerializer(Action<JsonSerializerOptions> configure) : this(configure.AndReturn(DefaultJsonSerializerOptions)) { }
 
-		private void ConfigureMandatorySerializerOptions() {
-			// deserialize extensions to Dictionary<string, object>
-			Options.Converters.Insert(0, new GraphQLExtensionsConverter());
-			// allow the JSON field "data" to match the property "Data" even without JsonNamingPolicy.CamelCase
-			Options.PropertyNameCaseInsensitive = true;
-		}
+        public SystemTextJsonSerializer(JsonSerializerOptions options)
+        {
+            Options = options;
+            ConfigureMandatorySerializerOptions();
+        }
 
-	    public string SerializeToString(GraphQL.GraphQLRequest request) {
-		    return JsonSerializer.Serialize(request, Options);
-	    }
+        private void ConfigureMandatorySerializerOptions()
+        {
+            // deserialize extensions to Dictionary<string, object>
+            Options.Converters.Insert(0, new GraphQLExtensionsConverter());
+            // allow the JSON field "data" to match the property "Data" even without JsonNamingPolicy.CamelCase
+            Options.PropertyNameCaseInsensitive = true;
+        }
 
-	    public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken) {
-		    return JsonSerializer.DeserializeAsync<GraphQLResponse<TResponse>>(stream, Options, cancellationToken).AsTask();
-	    }
+        public string SerializeToString(GraphQL.GraphQLRequest request)
+        {
+            return JsonSerializer.Serialize(request, Options);
+        }
 
-	    public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request) {
-		    return JsonSerializer.SerializeToUtf8Bytes(request, Options);
-	    }
+        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken)
+        {
+            return JsonSerializer.DeserializeAsync<GraphQLResponse<TResponse>>(stream, Options, cancellationToken).AsTask();
+        }
 
-	    public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream) {
-		    return JsonSerializer.DeserializeAsync<WebsocketMessageWrapper>(stream, Options).AsTask();
-		}
+        public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request)
+        {
+            return JsonSerializer.SerializeToUtf8Bytes(request, Options);
+        }
 
-	    public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes) {
-		    return JsonSerializer.Deserialize<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(new ReadOnlySpan<byte>(bytes),
-			    Options);
-	    }
+        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream)
+        {
+            return JsonSerializer.DeserializeAsync<WebsocketMessageWrapper>(stream, Options).AsTask();
+        }
+
+        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes)
+        {
+            return JsonSerializer.Deserialize<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(new ReadOnlySpan<byte>(bytes),
+                Options);
+        }
 
     }
 }

--- a/src/GraphQL.Client.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/SystemTextJsonSerializer.cs
@@ -35,31 +35,16 @@ namespace GraphQL.Client.Serializer.SystemTextJson
             Options.PropertyNameCaseInsensitive = true;
         }
 
-        public string SerializeToString(GraphQL.GraphQLRequest request)
-        {
-            return JsonSerializer.Serialize(request, Options);
-        }
+        public string SerializeToString(GraphQLRequest request) => JsonSerializer.Serialize(request, Options);
 
-        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken)
-        {
-            return JsonSerializer.DeserializeAsync<GraphQLResponse<TResponse>>(stream, Options, cancellationToken).AsTask();
-        }
+        public Task<GraphQLResponse<TResponse>> DeserializeFromUtf8StreamAsync<TResponse>(Stream stream, CancellationToken cancellationToken) => JsonSerializer.DeserializeAsync<GraphQLResponse<TResponse>>(stream, Options, cancellationToken).AsTask();
 
-        public byte[] SerializeToBytes(Abstractions.Websocket.GraphQLWebSocketRequest request)
-        {
-            return JsonSerializer.SerializeToUtf8Bytes(request, Options);
-        }
+        public byte[] SerializeToBytes(GraphQLWebSocketRequest request) => JsonSerializer.SerializeToUtf8Bytes(request, Options);
 
-        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream)
-        {
-            return JsonSerializer.DeserializeAsync<WebsocketMessageWrapper>(stream, Options).AsTask();
-        }
+        public Task<WebsocketMessageWrapper> DeserializeToWebsocketResponseWrapperAsync(Stream stream) => JsonSerializer.DeserializeAsync<WebsocketMessageWrapper>(stream, Options).AsTask();
 
-        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes)
-        {
-            return JsonSerializer.Deserialize<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(new ReadOnlySpan<byte>(bytes),
+        public GraphQLWebSocketResponse<GraphQLResponse<TResponse>> DeserializeToWebsocketResponse<TResponse>(byte[] bytes) =>
+            JsonSerializer.Deserialize<GraphQLWebSocketResponse<GraphQLResponse<TResponse>>>(new ReadOnlySpan<byte>(bytes),
                 Options);
-        }
-
     }
 }

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -11,172 +11,187 @@ using GraphQL.Client.Abstractions.Websocket;
 using GraphQL.Client.Http.Websocket;
 using GraphQL.Client.Serializer.Newtonsoft;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	public class GraphQLHttpClient : IGraphQLClient {
+    public class GraphQLHttpClient : IGraphQLClient
+    {
 
-		private readonly GraphQLHttpWebSocket graphQlHttpWebSocket;
-		private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-		private readonly ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object> subscriptionStreams = new ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object>();
-		private IGraphQLWebsocketJsonSerializer JsonSerializer => Options.JsonSerializer;
+        private readonly GraphQLHttpWebSocket graphQlHttpWebSocket;
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private readonly ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object> subscriptionStreams = new ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object>();
+        private IGraphQLWebsocketJsonSerializer JsonSerializer => Options.JsonSerializer;
 
-		/// <summary>
-		/// the instance of <see cref="HttpClient"/> which is used internally
-		/// </summary>
-		public HttpClient HttpClient { get; }
+        /// <summary>
+        /// the instance of <see cref="HttpClient"/> which is used internally
+        /// </summary>
+        public HttpClient HttpClient { get; }
 
-		/// <summary>
-		/// The Options	to be used
-		/// </summary>
-		public GraphQLHttpClientOptions Options { get; }
+        /// <summary>
+        /// The Options	to be used
+        /// </summary>
+        public GraphQLHttpClientOptions Options { get; }
 
-		/// <summary>
-		/// Publishes all exceptions which occur inside the websocket receive stream (i.e. for logging purposes)
-		/// </summary>
-		public IObservable<Exception> WebSocketReceiveErrors => graphQlHttpWebSocket.ReceiveErrors;
+        /// <summary>
+        /// Publishes all exceptions which occur inside the websocket receive stream (i.e. for logging purposes)
+        /// </summary>
+        public IObservable<Exception> WebSocketReceiveErrors => graphQlHttpWebSocket.ReceiveErrors;
 
-		/// <summary>
-		/// the websocket connection state
-		/// </summary>
-		public IObservable<GraphQLWebsocketConnectionState> WebsocketConnectionState =>
-			graphQlHttpWebSocket.ConnectionState;
+        /// <summary>
+        /// the websocket connection state
+        /// </summary>
+        public IObservable<GraphQLWebsocketConnectionState> WebsocketConnectionState =>
+            graphQlHttpWebSocket.ConnectionState;
 
-		#region Constructors
+        #region Constructors
 
-		public GraphQLHttpClient(string endPoint) : this(new Uri(endPoint)) { }
+        public GraphQLHttpClient(string endPoint) : this(new Uri(endPoint)) { }
 
-		public GraphQLHttpClient(Uri endPoint) : this(o => o.EndPoint = endPoint) { }
+        public GraphQLHttpClient(Uri endPoint) : this(o => o.EndPoint = endPoint) { }
 
-		public GraphQLHttpClient(Action<GraphQLHttpClientOptions> configure) : this(configure.New()) { }
+        public GraphQLHttpClient(Action<GraphQLHttpClientOptions> configure) : this(configure.New()) { }
 
-		public GraphQLHttpClient(GraphQLHttpClientOptions options) : this(options, new HttpClient(options.HttpMessageHandler)) { }
+        public GraphQLHttpClient(GraphQLHttpClientOptions options) : this(options, new HttpClient(options.HttpMessageHandler)) { }
 
-		public GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient) : this(options, httpClient, new NewtonsoftJsonSerializer()) { }
+        public GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient) : this(options, httpClient, new NewtonsoftJsonSerializer()) { }
 
-		public GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient, IGraphQLWebsocketJsonSerializer serializer) {
-			Options = options ?? throw new ArgumentNullException(nameof(options));
-			Options.JsonSerializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
-			this.HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-			this.graphQlHttpWebSocket = new GraphQLHttpWebSocket(GetWebSocketUri(), this);
-		}
+        public GraphQLHttpClient(GraphQLHttpClientOptions options, HttpClient httpClient, IGraphQLWebsocketJsonSerializer serializer)
+        {
+            Options = options ?? throw new ArgumentNullException(nameof(options));
+            Options.JsonSerializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            this.HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this.graphQlHttpWebSocket = new GraphQLHttpWebSocket(GetWebSocketUri(), this);
+        }
 
-		#endregion
+        #endregion
 
-		#region IGraphQLClient
+        #region IGraphQLClient
 
-		/// <inheritdoc />
-		public async Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default) {
-			if (Options.UseWebSocketForQueriesAndMutations)
-				return await this.graphQlHttpWebSocket.SendRequest<TResponse>(request, cancellationToken);
+        /// <inheritdoc />
+        public async Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+        {
+            if (Options.UseWebSocketForQueriesAndMutations)
+                return await this.graphQlHttpWebSocket.SendRequest<TResponse>(request, cancellationToken);
 
-			return await this.SendHttpPostRequestAsync<TResponse>(request, cancellationToken);
-		}
+            return await this.SendHttpPostRequestAsync<TResponse>(request, cancellationToken);
+        }
 
-		/// <inheritdoc />
-		public Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request,
-			CancellationToken cancellationToken = default)
-			=> SendQueryAsync<TResponse>(request, cancellationToken);
+        /// <inheritdoc />
+        public Task<GraphQLResponse<TResponse>> SendMutationAsync<TResponse>(GraphQLRequest request,
+            CancellationToken cancellationToken = default)
+            => SendQueryAsync<TResponse>(request, cancellationToken);
 
-		/// <inheritdoc />
-		public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request) {
-			if (disposed)
-				throw new ObjectDisposedException(nameof(GraphQLHttpClient));
+        /// <inheritdoc />
+        public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request)
+        {
+            if (disposed)
+                throw new ObjectDisposedException(nameof(GraphQLHttpClient));
 
-			var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
+            var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
 
-			if (subscriptionStreams.ContainsKey(key))
-				return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
+            if (subscriptionStreams.ContainsKey(key))
+                return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
 
-			var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request);
+            var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request);
 
-			subscriptionStreams.TryAdd(key, observable);
-			return observable;
-		}
-		
-		/// <inheritdoc />
-		public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler) {
-			if (disposed)
-				throw new ObjectDisposedException(nameof(GraphQLHttpClient));
+            subscriptionStreams.TryAdd(key, observable);
+            return observable;
+        }
 
-			var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
+        /// <inheritdoc />
+        public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler)
+        {
+            if (disposed)
+                throw new ObjectDisposedException(nameof(GraphQLHttpClient));
 
-			if (subscriptionStreams.ContainsKey(key))
-				return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
+            var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
 
-			var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
-			subscriptionStreams.TryAdd(key, observable);
-			return observable;
-		}
+            if (subscriptionStreams.ContainsKey(key))
+                return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
 
-		#endregion
+            var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
+            subscriptionStreams.TryAdd(key, observable);
+            return observable;
+        }
 
-		/// <summary>
-		/// explicitly opens the websocket connection. Will be closed again on disposing the last subscription
-		/// </summary>
-		/// <returns></returns>
-		public Task InitializeWebsocketConnection() => graphQlHttpWebSocket.InitializeWebSocket();
-		
-		#region Private Methods
+        #endregion
 
-		private async Task<GraphQLHttpResponse<TResponse>> SendHttpPostRequestAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default) {
-			var preprocessedRequest = await Options.PreprocessRequest(request, this);
-			using var httpRequestMessage = this.GenerateHttpRequestMessage(preprocessedRequest);
-			using var httpResponseMessage = await this.HttpClient.SendAsync(httpRequestMessage, cancellationToken);
-			if (!httpResponseMessage.IsSuccessStatusCode) {
-				throw new GraphQLHttpException(httpResponseMessage);
-			}
+        /// <summary>
+        /// explicitly opens the websocket connection. Will be closed again on disposing the last subscription
+        /// </summary>
+        /// <returns></returns>
+        public Task InitializeWebsocketConnection() => graphQlHttpWebSocket.InitializeWebSocket();
 
-			var bodyStream = await httpResponseMessage.Content.ReadAsStreamAsync();
-			var response = await JsonSerializer.DeserializeFromUtf8StreamAsync<TResponse>(bodyStream, cancellationToken);
-			return response.ToGraphQLHttpResponse(httpResponseMessage.Headers, httpResponseMessage.StatusCode);
-		}
+        #region Private Methods
 
-		private HttpRequestMessage GenerateHttpRequestMessage(GraphQLRequest request) {
-			var message = new HttpRequestMessage(HttpMethod.Post, this.Options.EndPoint) {
-				Content = new StringContent(JsonSerializer.SerializeToString(request), Encoding.UTF8, Options.MediaType)
-			};
+        private async Task<GraphQLHttpResponse<TResponse>> SendHttpPostRequestAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+        {
+            var preprocessedRequest = await Options.PreprocessRequest(request, this);
+            using var httpRequestMessage = this.GenerateHttpRequestMessage(preprocessedRequest);
+            using var httpResponseMessage = await this.HttpClient.SendAsync(httpRequestMessage, cancellationToken);
+            if (!httpResponseMessage.IsSuccessStatusCode)
+            {
+                throw new GraphQLHttpException(httpResponseMessage);
+            }
 
-			if (request is GraphQLHttpRequest httpRequest)
-				httpRequest.PreprocessHttpRequestMessage(message);
+            var bodyStream = await httpResponseMessage.Content.ReadAsStreamAsync();
+            var response = await JsonSerializer.DeserializeFromUtf8StreamAsync<TResponse>(bodyStream, cancellationToken);
+            return response.ToGraphQLHttpResponse(httpResponseMessage.Headers, httpResponseMessage.StatusCode);
+        }
 
-			return message;
-		}
+        private HttpRequestMessage GenerateHttpRequestMessage(GraphQLRequest request)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Post, this.Options.EndPoint)
+            {
+                Content = new StringContent(JsonSerializer.SerializeToString(request), Encoding.UTF8, Options.MediaType)
+            };
 
-		private Uri GetWebSocketUri() {
-			var webSocketSchema = this.Options.EndPoint.Scheme == "https" ? "wss" : "ws";
-			return new Uri($"{webSocketSchema}://{this.Options.EndPoint.Host}:{this.Options.EndPoint.Port}{this.Options.EndPoint.AbsolutePath}");
-		}
+            if (request is GraphQLHttpRequest httpRequest)
+                httpRequest.PreprocessHttpRequestMessage(message);
 
-		#endregion
+            return message;
+        }
+
+        private Uri GetWebSocketUri()
+        {
+            var webSocketSchema = this.Options.EndPoint.Scheme == "https" ? "wss" : "ws";
+            return new Uri($"{webSocketSchema}://{this.Options.EndPoint.Host}:{this.Options.EndPoint.Port}{this.Options.EndPoint.AbsolutePath}");
+        }
+
+        #endregion
 
 
-		#region IDisposable
+        #region IDisposable
 
-		/// <summary>
-		/// Releases unmanaged resources
-		/// </summary>
-		public void Dispose() {
-			lock (disposeLocker) {
-				if (!disposed) {
-					_dispose();
-				}
-			}
-		}
+        /// <summary>
+        /// Releases unmanaged resources
+        /// </summary>
+        public void Dispose()
+        {
+            lock (disposeLocker)
+            {
+                if (!disposed)
+                {
+                    _dispose();
+                }
+            }
+        }
 
-		private bool disposed = false;
-		private readonly object disposeLocker = new object();
+        private bool disposed = false;
+        private readonly object disposeLocker = new object();
 
-		private void _dispose() {
-			disposed = true;
-			Debug.WriteLine($"disposing GraphQLHttpClient on endpoint {Options.EndPoint}");
-			cancellationTokenSource.Cancel();
-			this.HttpClient.Dispose();
-			this.graphQlHttpWebSocket.Dispose();
-			cancellationTokenSource.Dispose();
-		}
+        private void _dispose()
+        {
+            disposed = true;
+            Debug.WriteLine($"disposing GraphQLHttpClient on endpoint {Options.EndPoint}");
+            cancellationTokenSource.Cancel();
+            this.HttpClient.Dispose();
+            this.graphQlHttpWebSocket.Dispose();
+            cancellationTokenSource.Dispose();
+        }
 
-		#endregion
+        #endregion
 
-	}
+    }
 
 }

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,9 +16,9 @@ namespace GraphQL.Client.Http
     public class GraphQLHttpClient : IGraphQLClient
     {
 
-        private readonly GraphQLHttpWebSocket graphQlHttpWebSocket;
-        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-        private readonly ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object> subscriptionStreams = new ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object>();
+        private readonly GraphQLHttpWebSocket _graphQlHttpWebSocket;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object> _subscriptionStreams = new ConcurrentDictionary<Tuple<GraphQLRequest, Type>, object>();
         private IGraphQLWebsocketJsonSerializer JsonSerializer => Options.JsonSerializer;
 
         /// <summary>
@@ -35,13 +34,13 @@ namespace GraphQL.Client.Http
         /// <summary>
         /// Publishes all exceptions which occur inside the websocket receive stream (i.e. for logging purposes)
         /// </summary>
-        public IObservable<Exception> WebSocketReceiveErrors => graphQlHttpWebSocket.ReceiveErrors;
+        public IObservable<Exception> WebSocketReceiveErrors => _graphQlHttpWebSocket.ReceiveErrors;
 
         /// <summary>
         /// the websocket connection state
         /// </summary>
         public IObservable<GraphQLWebsocketConnectionState> WebsocketConnectionState =>
-            graphQlHttpWebSocket.ConnectionState;
+            _graphQlHttpWebSocket.ConnectionState;
 
         #region Constructors
 
@@ -59,8 +58,8 @@ namespace GraphQL.Client.Http
         {
             Options = options ?? throw new ArgumentNullException(nameof(options));
             Options.JsonSerializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
-            this.HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            this.graphQlHttpWebSocket = new GraphQLHttpWebSocket(GetWebSocketUri(), this);
+            HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _graphQlHttpWebSocket = new GraphQLHttpWebSocket(GetWebSocketUri(), this);
         }
 
         #endregion
@@ -71,9 +70,9 @@ namespace GraphQL.Client.Http
         public async Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
         {
             if (Options.UseWebSocketForQueriesAndMutations)
-                return await this.graphQlHttpWebSocket.SendRequest<TResponse>(request, cancellationToken);
+                return await _graphQlHttpWebSocket.SendRequest<TResponse>(request, cancellationToken);
 
-            return await this.SendHttpPostRequestAsync<TResponse>(request, cancellationToken);
+            return await SendHttpPostRequestAsync<TResponse>(request, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -84,33 +83,33 @@ namespace GraphQL.Client.Http
         /// <inheritdoc />
         public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request)
         {
-            if (disposed)
+            if (_disposed)
                 throw new ObjectDisposedException(nameof(GraphQLHttpClient));
 
             var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
 
-            if (subscriptionStreams.ContainsKey(key))
-                return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
+            if (_subscriptionStreams.ContainsKey(key))
+                return (IObservable<GraphQLResponse<TResponse>>)_subscriptionStreams[key];
 
-            var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request);
+            var observable = _graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request);
 
-            subscriptionStreams.TryAdd(key, observable);
+            _subscriptionStreams.TryAdd(key, observable);
             return observable;
         }
 
         /// <inheritdoc />
         public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler)
         {
-            if (disposed)
+            if (_disposed)
                 throw new ObjectDisposedException(nameof(GraphQLHttpClient));
 
             var key = new Tuple<GraphQLRequest, Type>(request, typeof(TResponse));
 
-            if (subscriptionStreams.ContainsKey(key))
-                return (IObservable<GraphQLResponse<TResponse>>)subscriptionStreams[key];
+            if (_subscriptionStreams.ContainsKey(key))
+                return (IObservable<GraphQLResponse<TResponse>>)_subscriptionStreams[key];
 
-            var observable = graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
-            subscriptionStreams.TryAdd(key, observable);
+            var observable = _graphQlHttpWebSocket.CreateSubscriptionStream<TResponse>(request, exceptionHandler);
+            _subscriptionStreams.TryAdd(key, observable);
             return observable;
         }
 
@@ -120,15 +119,15 @@ namespace GraphQL.Client.Http
         /// explicitly opens the websocket connection. Will be closed again on disposing the last subscription
         /// </summary>
         /// <returns></returns>
-        public Task InitializeWebsocketConnection() => graphQlHttpWebSocket.InitializeWebSocket();
+        public Task InitializeWebsocketConnection() => _graphQlHttpWebSocket.InitializeWebSocket();
 
         #region Private Methods
 
         private async Task<GraphQLHttpResponse<TResponse>> SendHttpPostRequestAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
         {
             var preprocessedRequest = await Options.PreprocessRequest(request, this);
-            using var httpRequestMessage = this.GenerateHttpRequestMessage(preprocessedRequest);
-            using var httpResponseMessage = await this.HttpClient.SendAsync(httpRequestMessage, cancellationToken);
+            using var httpRequestMessage = GenerateHttpRequestMessage(preprocessedRequest);
+            using var httpResponseMessage = await HttpClient.SendAsync(httpRequestMessage, cancellationToken);
             if (!httpResponseMessage.IsSuccessStatusCode)
             {
                 throw new GraphQLHttpException(httpResponseMessage);
@@ -141,7 +140,7 @@ namespace GraphQL.Client.Http
 
         private HttpRequestMessage GenerateHttpRequestMessage(GraphQLRequest request)
         {
-            var message = new HttpRequestMessage(HttpMethod.Post, this.Options.EndPoint)
+            var message = new HttpRequestMessage(HttpMethod.Post, Options.EndPoint)
             {
                 Content = new StringContent(JsonSerializer.SerializeToString(request), Encoding.UTF8, Options.MediaType)
             };
@@ -154,8 +153,8 @@ namespace GraphQL.Client.Http
 
         private Uri GetWebSocketUri()
         {
-            var webSocketSchema = this.Options.EndPoint.Scheme == "https" ? "wss" : "ws";
-            return new Uri($"{webSocketSchema}://{this.Options.EndPoint.Host}:{this.Options.EndPoint.Port}{this.Options.EndPoint.AbsolutePath}");
+            var webSocketSchema = Options.EndPoint.Scheme == "https" ? "wss" : "ws";
+            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}");
         }
 
         #endregion
@@ -168,26 +167,26 @@ namespace GraphQL.Client.Http
         /// </summary>
         public void Dispose()
         {
-            lock (disposeLocker)
+            lock (_disposeLocker)
             {
-                if (!disposed)
+                if (!_disposed)
                 {
                     _dispose();
                 }
             }
         }
 
-        private bool disposed = false;
-        private readonly object disposeLocker = new object();
+        private bool _disposed = false;
+        private readonly object _disposeLocker = new object();
 
         private void _dispose()
         {
-            disposed = true;
+            _disposed = true;
             Debug.WriteLine($"disposing GraphQLHttpClient on endpoint {Options.EndPoint}");
-            cancellationTokenSource.Cancel();
-            this.HttpClient.Dispose();
-            this.graphQlHttpWebSocket.Dispose();
-            cancellationTokenSource.Dispose();
+            _cancellationTokenSource.Cancel();
+            HttpClient.Dispose();
+            _graphQlHttpWebSocket.Dispose();
+            _cancellationTokenSource.Dispose();
         }
 
         #endregion

--- a/src/GraphQL.Client/GraphQLHttpClientExtensions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientExtensions.cs
@@ -2,31 +2,35 @@ using System;
 using System.Net.WebSockets;
 using GraphQL.Client.Abstractions;
 
-namespace GraphQL.Client.Http {
-	public static class GraphQLHttpClientExtensions {
-		/// <summary>
-		/// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
-		/// All subscriptions made to this stream share the same hot observable.<br/>
-		/// All <see cref="WebSocketException"/>s are passed to the <paramref name="webSocketExceptionHandler"/> to be handled externally.<br/>
-		/// If the <paramref name="webSocketExceptionHandler"/> completes normally, the subscription is recreated with a new connection attempt.<br/>
-		/// Other <see cref="Exception"/>s or any exception thrown by <paramref name="webSocketExceptionHandler"/> will cause the sequence to fail.
-		/// </summary>
-		/// <param name="client">the GraphQL client</param>
-		/// <param name="request">the GraphQL request for this subscription</param>
-		/// <param name="webSocketExceptionHandler">an external handler for all <see cref="WebSocketException"/>s occuring within the sequence</param>
-		/// <returns>an observable stream for the specified subscription</returns>
-		public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(this IGraphQLClient client,
-			GraphQLRequest request, Action<WebSocketException> webSocketExceptionHandler) {
-			return client.CreateSubscriptionStream<TResponse>(request, e => {
-				if (e is WebSocketException webSocketException)
-					webSocketExceptionHandler(webSocketException);
-				else
-					throw e;
-			});
-		}
+namespace GraphQL.Client.Http
+{
+    public static class GraphQLHttpClientExtensions
+    {
+        /// <summary>
+        /// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
+        /// All subscriptions made to this stream share the same hot observable.<br/>
+        /// All <see cref="WebSocketException"/>s are passed to the <paramref name="webSocketExceptionHandler"/> to be handled externally.<br/>
+        /// If the <paramref name="webSocketExceptionHandler"/> completes normally, the subscription is recreated with a new connection attempt.<br/>
+        /// Other <see cref="Exception"/>s or any exception thrown by <paramref name="webSocketExceptionHandler"/> will cause the sequence to fail.
+        /// </summary>
+        /// <param name="client">the GraphQL client</param>
+        /// <param name="request">the GraphQL request for this subscription</param>
+        /// <param name="webSocketExceptionHandler">an external handler for all <see cref="WebSocketException"/>s occuring within the sequence</param>
+        /// <returns>an observable stream for the specified subscription</returns>
+        public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(this IGraphQLClient client,
+            GraphQLRequest request, Action<WebSocketException> webSocketExceptionHandler)
+        {
+            return client.CreateSubscriptionStream<TResponse>(request, e =>
+            {
+                if (e is WebSocketException webSocketException)
+                    webSocketExceptionHandler(webSocketException);
+                else
+                    throw e;
+            });
+        }
 
-		public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
-			this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<WebSocketException> webSocketExceptionHandler)
-			=> client.CreateSubscriptionStream<TResponse>(request, webSocketExceptionHandler);
-	}
+        public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
+            this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<WebSocketException> webSocketExceptionHandler)
+            => client.CreateSubscriptionStream<TResponse>(request, webSocketExceptionHandler);
+    }
 }

--- a/src/GraphQL.Client/GraphQLHttpClientExtensions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientExtensions.cs
@@ -18,19 +18,20 @@ namespace GraphQL.Client.Http
         /// <param name="webSocketExceptionHandler">an external handler for all <see cref="WebSocketException"/>s occuring within the sequence</param>
         /// <returns>an observable stream for the specified subscription</returns>
         public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(this IGraphQLClient client,
-            GraphQLRequest request, Action<WebSocketException> webSocketExceptionHandler)
-        {
-            return client.CreateSubscriptionStream<TResponse>(request, e =>
+            GraphQLRequest request, Action<WebSocketException> webSocketExceptionHandler) =>
+            client.CreateSubscriptionStream<TResponse>(request, e =>
             {
                 if (e is WebSocketException webSocketException)
                     webSocketExceptionHandler(webSocketException);
                 else
                     throw e;
             });
-        }
 
         public static IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(
             this IGraphQLClient client, GraphQLRequest request, Func<TResponse> defineResponseType, Action<WebSocketException> webSocketExceptionHandler)
-            => client.CreateSubscriptionStream<TResponse>(request, webSocketExceptionHandler);
+        {
+            _ = defineResponseType;
+            return client.CreateSubscriptionStream<TResponse>(request, webSocketExceptionHandler);
+        }
     }
 }

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -4,55 +4,58 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using GraphQL.Client.Abstractions.Websocket;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	/// <summary>
-	/// The Options that the <see cref="GraphQLHttpClient"/> will use
-	/// </summary>
-	public class GraphQLHttpClientOptions {
+    /// <summary>
+    /// The Options that the <see cref="GraphQLHttpClient"/> will use
+    /// </summary>
+    public class GraphQLHttpClientOptions
+    {
 
-		/// <summary>
-		/// The GraphQL EndPoint to be used
-		/// </summary>
-		public Uri EndPoint { get; set; }
+        /// <summary>
+        /// The GraphQL EndPoint to be used
+        /// </summary>
+        public Uri EndPoint { get; set; }
 
-		/// <summary>
-		/// the json serializer
-		/// </summary>
-		public IGraphQLWebsocketJsonSerializer JsonSerializer { get; set; }
+        /// <summary>
+        /// the json serializer
+        /// </summary>
+        public IGraphQLWebsocketJsonSerializer JsonSerializer { get; set; }
 
-		/// <summary>
-		/// The <see cref="System.Net.Http.HttpMessageHandler"/> that is going to be used
-		/// </summary>
-		public HttpMessageHandler HttpMessageHandler { get; set; } = new HttpClientHandler();
+        /// <summary>
+        /// The <see cref="System.Net.Http.HttpMessageHandler"/> that is going to be used
+        /// </summary>
+        public HttpMessageHandler HttpMessageHandler { get; set; } = new HttpClientHandler();
 
-		/// <summary>
-		/// The <see cref="MediaTypeHeaderValue"/> that will be send on POST
-		/// </summary>
-		public string MediaType { get; set; } = "application/json"; // This should be "application/graphql" also "application/x-www-form-urlencoded" is Accepted
+        /// <summary>
+        /// The <see cref="MediaTypeHeaderValue"/> that will be send on POST
+        /// </summary>
+        public string MediaType { get; set; } = "application/json"; // This should be "application/graphql" also "application/x-www-form-urlencoded" is Accepted
 
-		/// <summary>
-		/// The back-off strategy for automatic websocket/subscription reconnects. Calculates the delay before the next connection attempt is made.<br/>
-		/// default formula: min(n, 5) * 1,5 * random(0.0, 1.0)
-		/// </summary>
-		public Func<int, TimeSpan> BackOffStrategy { get; set; } = n => {
-			var rnd = new Random();
-			return TimeSpan.FromSeconds(Math.Min(n, 5) * 1.5 + rnd.NextDouble());
-		};
+        /// <summary>
+        /// The back-off strategy for automatic websocket/subscription reconnects. Calculates the delay before the next connection attempt is made.<br/>
+        /// default formula: min(n, 5) * 1,5 * random(0.0, 1.0)
+        /// </summary>
+        public Func<int, TimeSpan> BackOffStrategy { get; set; } = n =>
+        {
+            var rnd = new Random();
+            return TimeSpan.FromSeconds(Math.Min(n, 5) * 1.5 + rnd.NextDouble());
+        };
 
-		/// <summary>
-		/// If <see langword="true"/>, the websocket connection is also used for regular queries and mutations
-		/// </summary>
-		public bool UseWebSocketForQueriesAndMutations { get; set; } = false;
+        /// <summary>
+        /// If <see langword="true"/>, the websocket connection is also used for regular queries and mutations
+        /// </summary>
+        public bool UseWebSocketForQueriesAndMutations { get; set; } = false;
 
-		/// <summary>
-		/// Request preprocessing function. Can be used i.e. to inject authorization info into a GraphQL request payload.
-		/// </summary>
-		public Func<GraphQLRequest, GraphQLHttpClient, Task<GraphQLRequest>> PreprocessRequest { get; set; } = (request, client) => Task.FromResult(request);
+        /// <summary>
+        /// Request preprocessing function. Can be used i.e. to inject authorization info into a GraphQL request payload.
+        /// </summary>
+        public Func<GraphQLRequest, GraphQLHttpClient, Task<GraphQLRequest>> PreprocessRequest { get; set; } = (request, client) => Task.FromResult(request);
 
-		/// <summary>
-		/// This callback is called after successfully establishing a websocket connection but before any regular request is made. 
-		/// </summary>
-		public Func<GraphQLHttpClient, Task> OnWebsocketConnected { get; set; } = client => Task.CompletedTask;
-	}
+        /// <summary>
+        /// This callback is called after successfully establishing a websocket connection but before any regular request is made. 
+        /// </summary>
+        public Func<GraphQLHttpClient, Task> OnWebsocketConnected { get; set; } = client => Task.CompletedTask;
+    }
 }

--- a/src/GraphQL.Client/GraphQLHttpException.cs
+++ b/src/GraphQL.Client/GraphQLHttpException.cs
@@ -1,26 +1,29 @@
 using System;
 using System.Net.Http;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	/// <summary>
-	/// An exception thrown on unexpected <see cref="System.Net.Http.HttpResponseMessage"/>
-	/// </summary>
-	public class GraphQLHttpException : Exception {
+    /// <summary>
+    /// An exception thrown on unexpected <see cref="System.Net.Http.HttpResponseMessage"/>
+    /// </summary>
+    public class GraphQLHttpException : Exception
+    {
 
-		/// <summary>
-		/// The <see cref="System.Net.Http.HttpResponseMessage"/>
-		/// </summary>
-		public HttpResponseMessage HttpResponseMessage { get; }
+        /// <summary>
+        /// The <see cref="System.Net.Http.HttpResponseMessage"/>
+        /// </summary>
+        public HttpResponseMessage HttpResponseMessage { get; }
 
-		/// <summary>
-		/// Creates a new instance of <see cref="GraphQLHttpException"/>
-		/// </summary>
-		/// <param name="httpResponseMessage">The unexpected <see cref="System.Net.Http.HttpResponseMessage"/></param>
-		public GraphQLHttpException(HttpResponseMessage httpResponseMessage) : base($"Unexpected {nameof(System.Net.Http.HttpResponseMessage)} with code: {httpResponseMessage?.StatusCode}") {
-			this.HttpResponseMessage = httpResponseMessage ?? throw new ArgumentNullException(nameof(httpResponseMessage));
-		}
+        /// <summary>
+        /// Creates a new instance of <see cref="GraphQLHttpException"/>
+        /// </summary>
+        /// <param name="httpResponseMessage">The unexpected <see cref="System.Net.Http.HttpResponseMessage"/></param>
+        public GraphQLHttpException(HttpResponseMessage httpResponseMessage) : base($"Unexpected {nameof(System.Net.Http.HttpResponseMessage)} with code: {httpResponseMessage?.StatusCode}")
+        {
+            this.HttpResponseMessage = httpResponseMessage ?? throw new ArgumentNullException(nameof(httpResponseMessage));
+        }
 
-	}
+    }
 
 }

--- a/src/GraphQL.Client/GraphQLHttpException.cs
+++ b/src/GraphQL.Client/GraphQLHttpException.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Client.Http
         /// <param name="httpResponseMessage">The unexpected <see cref="System.Net.Http.HttpResponseMessage"/></param>
         public GraphQLHttpException(HttpResponseMessage httpResponseMessage) : base($"Unexpected {nameof(System.Net.Http.HttpResponseMessage)} with code: {httpResponseMessage?.StatusCode}")
         {
-            this.HttpResponseMessage = httpResponseMessage ?? throw new ArgumentNullException(nameof(httpResponseMessage));
+            HttpResponseMessage = httpResponseMessage ?? throw new ArgumentNullException(nameof(httpResponseMessage));
         }
 
     }

--- a/src/GraphQL.Client/GraphQLHttpRequest.cs
+++ b/src/GraphQL.Client/GraphQLHttpRequest.cs
@@ -2,21 +2,23 @@ using System;
 using System.Net.Http;
 using System.Runtime.Serialization;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	public class GraphQLHttpRequest : GraphQLRequest {
-		public GraphQLHttpRequest()
-		{
-		}
+    public class GraphQLHttpRequest : GraphQLRequest
+    {
+        public GraphQLHttpRequest()
+        {
+        }
 
-		public GraphQLHttpRequest(string query, object? variables = null, string? operationName = null) : base(query, variables, operationName)
-		{
-		}
+        public GraphQLHttpRequest(string query, object? variables = null, string? operationName = null) : base(query, variables, operationName)
+        {
+        }
 
-		/// <summary>
-		/// Allows to preprocess a <see cref="HttpRequestMessage"/> before it is sent, i.e. add custom headers
-		/// </summary>
-		[IgnoreDataMember]
-		public Action<HttpRequestMessage> PreprocessHttpRequestMessage { get; set; } = message => { };
-	}
+        /// <summary>
+        /// Allows to preprocess a <see cref="HttpRequestMessage"/> before it is sent, i.e. add custom headers
+        /// </summary>
+        [IgnoreDataMember]
+        public Action<HttpRequestMessage> PreprocessHttpRequestMessage { get; set; } = message => { };
+    }
 }

--- a/src/GraphQL.Client/GraphQLHttpResponse.cs
+++ b/src/GraphQL.Client/GraphQLHttpResponse.cs
@@ -2,35 +2,41 @@ using System;
 using System.Net;
 using System.Net.Http.Headers;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	public class GraphQLHttpResponse<T>: GraphQLResponse<T> {
-		public GraphQLHttpResponse(GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode) {
-			Data = response.Data;
-			Errors = response.Errors;
-			Extensions = response.Extensions;
-			ResponseHeaders = responseHeaders;
-			StatusCode = statusCode;
-		}
+    public class GraphQLHttpResponse<T> : GraphQLResponse<T>
+    {
+        public GraphQLHttpResponse(GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode)
+        {
+            Data = response.Data;
+            Errors = response.Errors;
+            Extensions = response.Extensions;
+            ResponseHeaders = responseHeaders;
+            StatusCode = statusCode;
+        }
 
-		public HttpResponseHeaders ResponseHeaders { get; set; }
-		public HttpStatusCode StatusCode { get; set; }
-	}
+        public HttpResponseHeaders ResponseHeaders { get; set; }
+        public HttpStatusCode StatusCode { get; set; }
+    }
 
-	public static class GraphQLResponseExtensions {
-		public static GraphQLHttpResponse<T> ToGraphQLHttpResponse<T>(this GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode) {
-			return new GraphQLHttpResponse<T>(response, responseHeaders, statusCode);
-		}
+    public static class GraphQLResponseExtensions
+    {
+        public static GraphQLHttpResponse<T> ToGraphQLHttpResponse<T>(this GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode)
+        {
+            return new GraphQLHttpResponse<T>(response, responseHeaders, statusCode);
+        }
 
-		/// <summary>
-		/// Casts <paramref name="response"/> to <see cref="GraphQLHttpResponse{T}"/>. Throws ig the cast fails.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="response"></param>
-		/// <exception cref="InvalidCastException"><paramref name="response"/> is not a <see cref="GraphQLHttpResponse{T}"/></exception>
-		/// <returns></returns>
-		public static GraphQLHttpResponse<T> AsGraphQLHttpResponse<T>(this GraphQLResponse<T> response) {
-			return (GraphQLHttpResponse<T>) response;
-		}
-	}
+        /// <summary>
+        /// Casts <paramref name="response"/> to <see cref="GraphQLHttpResponse{T}"/>. Throws ig the cast fails.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="response"></param>
+        /// <exception cref="InvalidCastException"><paramref name="response"/> is not a <see cref="GraphQLHttpResponse{T}"/></exception>
+        /// <returns></returns>
+        public static GraphQLHttpResponse<T> AsGraphQLHttpResponse<T>(this GraphQLResponse<T> response)
+        {
+            return (GraphQLHttpResponse<T>)response;
+        }
+    }
 }

--- a/src/GraphQL.Client/GraphQLHttpResponse.cs
+++ b/src/GraphQL.Client/GraphQLHttpResponse.cs
@@ -22,10 +22,7 @@ namespace GraphQL.Client.Http
 
     public static class GraphQLResponseExtensions
     {
-        public static GraphQLHttpResponse<T> ToGraphQLHttpResponse<T>(this GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode)
-        {
-            return new GraphQLHttpResponse<T>(response, responseHeaders, statusCode);
-        }
+        public static GraphQLHttpResponse<T> ToGraphQLHttpResponse<T>(this GraphQLResponse<T> response, HttpResponseHeaders responseHeaders, HttpStatusCode statusCode) => new GraphQLHttpResponse<T>(response, responseHeaders, statusCode);
 
         /// <summary>
         /// Casts <paramref name="response"/> to <see cref="GraphQLHttpResponse{T}"/>. Throws ig the cast fails.
@@ -34,9 +31,6 @@ namespace GraphQL.Client.Http
         /// <param name="response"></param>
         /// <exception cref="InvalidCastException"><paramref name="response"/> is not a <see cref="GraphQLHttpResponse{T}"/></exception>
         /// <returns></returns>
-        public static GraphQLHttpResponse<T> AsGraphQLHttpResponse<T>(this GraphQLResponse<T> response)
-        {
-            return (GraphQLHttpResponse<T>)response;
-        }
+        public static GraphQLHttpResponse<T> AsGraphQLHttpResponse<T>(this GraphQLResponse<T> response) => (GraphQLHttpResponse<T>)response;
     }
 }

--- a/src/GraphQL.Client/GraphQLSubscriptionException.cs
+++ b/src/GraphQL.Client/GraphQLSubscriptionException.cs
@@ -1,25 +1,30 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace GraphQL.Client.Http {
-	[Serializable]
-	public class GraphQLSubscriptionException : Exception {
-		//
-		// For guidelines regarding the creation of new exception types, see
-		//    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
-		// and
-		//    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
-		//
+namespace GraphQL.Client.Http
+{
+    [Serializable]
+    public class GraphQLSubscriptionException : Exception
+    {
+        //
+        // For guidelines regarding the creation of new exception types, see
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
+        // and
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
+        //
 
-		public GraphQLSubscriptionException() {
-		}
+        public GraphQLSubscriptionException()
+        {
+        }
 
-		public GraphQLSubscriptionException(object error) : base(error.ToString()) {
-		}
+        public GraphQLSubscriptionException(object error) : base(error.ToString())
+        {
+        }
 
-		protected GraphQLSubscriptionException(
-			SerializationInfo info,
-			StreamingContext context) : base(info, context) {
-		}
-	}
+        protected GraphQLSubscriptionException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
 }

--- a/src/GraphQL.Client/HttpClientExtensions.cs
+++ b/src/GraphQL.Client/HttpClientExtensions.cs
@@ -1,18 +1,20 @@
 using System;
 using System.Net.Http;
 
-namespace GraphQL.Client.Http {
+namespace GraphQL.Client.Http
+{
 
-	public static class HttpClientExtensions {
+    public static class HttpClientExtensions
+    {
 
-		public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, string endPoint) =>
-			httpClient.AsGraphQLClient(new Uri(endPoint));
+        public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, string endPoint) =>
+            httpClient.AsGraphQLClient(new Uri(endPoint));
 
-		public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, Uri endPoint) =>
-			new GraphQLHttpClient(new GraphQLHttpClientOptions { EndPoint = endPoint }, httpClient);
+        public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, Uri endPoint) =>
+            new GraphQLHttpClient(new GraphQLHttpClientOptions { EndPoint = endPoint }, httpClient);
 
-		public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, GraphQLHttpClientOptions graphQLHttpClientOptions) =>
-			new GraphQLHttpClient(graphQLHttpClientOptions, httpClient);
-	}
+        public static GraphQLHttpClient AsGraphQLClient(this HttpClient httpClient, GraphQLHttpClientOptions graphQLHttpClientOptions) =>
+            new GraphQLHttpClient(graphQLHttpClientOptions, httpClient);
+    }
 
 }

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -12,342 +12,387 @@ using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Client.Abstractions.Websocket;
 
-namespace GraphQL.Client.Http.Websocket {
-	internal class GraphQLHttpWebSocket : IDisposable {
+namespace GraphQL.Client.Http.Websocket
+{
+    internal class GraphQLHttpWebSocket : IDisposable
+    {
 
-		#region Private fields
+        #region Private fields
 
-		private readonly Uri webSocketUri;
-		private readonly GraphQLHttpClient client;
-		private readonly ArraySegment<byte> buffer;
-		private readonly CancellationTokenSource internalCancellationTokenSource = new CancellationTokenSource();
-		private readonly CancellationToken internalCancellationToken;
-		private readonly Subject<GraphQLWebSocketRequest> requestSubject = new Subject<GraphQLWebSocketRequest>();
-		private readonly Subject<Exception> exceptionSubject = new Subject<Exception>();
-		private readonly BehaviorSubject<GraphQLWebsocketConnectionState> stateSubject =
-			new BehaviorSubject<GraphQLWebsocketConnectionState>(GraphQLWebsocketConnectionState.Disconnected);
-		private readonly IDisposable requestSubscription;
-		private readonly EventLoopScheduler receiveLoopScheduler = new EventLoopScheduler();
-		private readonly EventLoopScheduler sendLoopScheduler = new EventLoopScheduler();
+        private readonly Uri webSocketUri;
+        private readonly GraphQLHttpClient client;
+        private readonly ArraySegment<byte> buffer;
+        private readonly CancellationTokenSource internalCancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationToken internalCancellationToken;
+        private readonly Subject<GraphQLWebSocketRequest> requestSubject = new Subject<GraphQLWebSocketRequest>();
+        private readonly Subject<Exception> exceptionSubject = new Subject<Exception>();
+        private readonly BehaviorSubject<GraphQLWebsocketConnectionState> stateSubject =
+            new BehaviorSubject<GraphQLWebsocketConnectionState>(GraphQLWebsocketConnectionState.Disconnected);
+        private readonly IDisposable requestSubscription;
+        private readonly EventLoopScheduler receiveLoopScheduler = new EventLoopScheduler();
+        private readonly EventLoopScheduler sendLoopScheduler = new EventLoopScheduler();
 
-		private int connectionAttempt = 0;
-		private IConnectableObservable<WebsocketMessageWrapper> incomingMessages;
-		private IDisposable incomingMessagesConnection;
-		private GraphQLHttpClientOptions Options => client.Options;
-		
-		private Task initializeWebSocketTask = Task.CompletedTask;
-		private readonly object initializeLock = new object();
+        private int connectionAttempt = 0;
+        private IConnectableObservable<WebsocketMessageWrapper> incomingMessages;
+        private IDisposable incomingMessagesConnection;
+        private GraphQLHttpClientOptions Options => client.Options;
+
+        private Task initializeWebSocketTask = Task.CompletedTask;
+        private readonly object initializeLock = new object();
 
 #if NETFRAMEWORK
 		private WebSocket clientWebSocket = null;
 #else
-		private ClientWebSocket clientWebSocket = null;
+        private ClientWebSocket clientWebSocket = null;
 #endif
 
-		#endregion
-
-		
-		#region Public properties
-
-		/// <summary>
-		/// The current websocket state
-		/// </summary>
-		public WebSocketState WebSocketState => clientWebSocket?.State ?? WebSocketState.None;
-
-		/// <summary>
-		/// Publishes all errors which occur within the receive pipeline
-		/// </summary>
-		public IObservable<Exception> ReceiveErrors => exceptionSubject.AsObservable();
-
-		/// <summary>
-		/// Publishes the connection state of the <see cref="GraphQLHttpWebSocket"/>
-		/// </summary>
-		public IObservable<GraphQLWebsocketConnectionState> ConnectionState => stateSubject.DistinctUntilChanged();
-
-		/// <summary>
-		/// Publishes all messages which are received on the websocket
-		/// </summary>
-		public IObservable<WebsocketMessageWrapper> IncomingMessageStream { get; }
-
-		#endregion
-
-		
-		public GraphQLHttpWebSocket(Uri webSocketUri, GraphQLHttpClient client) {
-			internalCancellationToken = internalCancellationTokenSource.Token;
-			this.webSocketUri = webSocketUri;
-			this.client = client;
-			buffer = new ArraySegment<byte>(new byte[8192]);
-			IncomingMessageStream = GetMessageStream();
-			receiveLoopScheduler.Schedule(() =>
-				Debug.WriteLine($"receive loop scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
-
-			requestSubscription = requestSubject
-				.ObserveOn(sendLoopScheduler)
-				.Subscribe(async request => await SendWebSocketRequest(request));
-		}
+        #endregion
 
 
-		#region Send requests
+        #region Public properties
 
-		/// <summary>
-		/// Create a new subscription stream
-		/// </summary>
-		/// <typeparam name="TResponse">the response type</typeparam>
-		/// <param name="request">the <see cref="GraphQLRequest"/> to start the subscription</param>
-		/// <param name="exceptionHandler">Optional: exception handler for handling exceptions within the receive pipeline</param>
-		/// <returns>a <see cref="IObservable{TResponse}"/> which represents the subscription</returns>
-		public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler = null) {
-			return Observable.Defer(() =>
-				Observable.Create<GraphQLResponse<TResponse>>(async observer => {
-					Debug.WriteLine($"Create observable thread id: {Thread.CurrentThread.ManagedThreadId}");
-					await client.Options.PreprocessRequest(request, client);
-					var startRequest = new GraphQLWebSocketRequest {
-						Id = Guid.NewGuid().ToString("N"),
-						Type = GraphQLWebSocketMessageType.GQL_START,
-						Payload = request
-					};
-					var closeRequest = new GraphQLWebSocketRequest {
-						Id = startRequest.Id,
-						Type = GraphQLWebSocketMessageType.GQL_STOP
-					};
-					var initRequest = new GraphQLWebSocketRequest {
-						Id = startRequest.Id,
-						Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-					};
+        /// <summary>
+        /// The current websocket state
+        /// </summary>
+        public WebSocketState WebSocketState => clientWebSocket?.State ?? WebSocketState.None;
 
-					var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>
-						IncomingMessageStream
-							// ignore null values and messages for other requests
-							.Where(response => response != null && response.Id == startRequest.Id)
-							.Subscribe(response => {
-								// terminate the sequence when a 'complete' message is received
-								if (response.Type == GraphQLWebSocketMessageType.GQL_COMPLETE) {
-									Debug.WriteLine($"received 'complete' message on subscription {startRequest.Id}");
-									o.OnCompleted();
-									return;
-								}
+        /// <summary>
+        /// Publishes all errors which occur within the receive pipeline
+        /// </summary>
+        public IObservable<Exception> ReceiveErrors => exceptionSubject.AsObservable();
 
-								// post the GraphQLResponse to the stream (even if a GraphQL error occurred)
-								Debug.WriteLine($"received payload on subscription {startRequest.Id} (thread {Thread.CurrentThread.ManagedThreadId})");
-								var typedResponse =
-									client.Options.JsonSerializer.DeserializeToWebsocketResponse<TResponse>(
-										response.MessageBytes);
-								o.OnNext(typedResponse.Payload);
+        /// <summary>
+        /// Publishes the connection state of the <see cref="GraphQLHttpWebSocket"/>
+        /// </summary>
+        public IObservable<GraphQLWebsocketConnectionState> ConnectionState => stateSubject.DistinctUntilChanged();
 
-								// in case of a GraphQL error, terminate the sequence after the response has been posted
-								if (response.Type == GraphQLWebSocketMessageType.GQL_ERROR) {
-									Debug.WriteLine($"terminating subscription {startRequest.Id} because of a GraphQL error");
-									o.OnCompleted();
-								}
-								},
-								e => {
-									Debug.WriteLine($"response stream for subscription {startRequest.Id} failed: {e}");
-									o.OnError(e);
-								},
-								() => {
-									Debug.WriteLine($"response stream for subscription {startRequest.Id} completed");
-									o.OnCompleted();
-								})
-					);
+        /// <summary>
+        /// Publishes all messages which are received on the websocket
+        /// </summary>
+        public IObservable<WebsocketMessageWrapper> IncomingMessageStream { get; }
 
-					try {
-						// initialize websocket (completes immediately if socket is already open)
-						await InitializeWebSocket();
-					}
-					catch (Exception e) {
-						// subscribe observer to failed observable
-						return Observable.Throw<GraphQLResponse<TResponse>>(e).Subscribe(observer);
-					}
+        #endregion
 
-					var disposable = new CompositeDisposable(
-						observable.Subscribe(observer),
-						Disposable.Create(async () => {
-							// only try to send close request on open websocket
-							if (WebSocketState != WebSocketState.Open) return;
 
-							try {
-								Debug.WriteLine($"sending close message on subscription {startRequest.Id}");
-								await QueueWebSocketRequest(closeRequest);
-							}
-							// do not break on disposing
-							catch (OperationCanceledException) { }
-						})
-					);
+        public GraphQLHttpWebSocket(Uri webSocketUri, GraphQLHttpClient client)
+        {
+            internalCancellationToken = internalCancellationTokenSource.Token;
+            this.webSocketUri = webSocketUri;
+            this.client = client;
+            buffer = new ArraySegment<byte>(new byte[8192]);
+            IncomingMessageStream = GetMessageStream();
+            receiveLoopScheduler.Schedule(() =>
+                Debug.WriteLine($"receive loop scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
 
-					// send connection init
-					Debug.WriteLine($"sending connection init on subscription {startRequest.Id}");
-					try {
-						await QueueWebSocketRequest(initRequest);
-					}
-					catch (Exception e) {
-						Console.WriteLine(e);
-						throw;
-					}
+            requestSubscription = requestSubject
+                .ObserveOn(sendLoopScheduler)
+                .Subscribe(async request => await SendWebSocketRequest(request));
+        }
 
-					Debug.WriteLine($"sending initial message on subscription {startRequest.Id}");
-					// send subscription request
-					try {
-						await QueueWebSocketRequest(startRequest);
-					}
-					catch (Exception e) {
-						Console.WriteLine(e);
-						throw;
-					}
 
-					return disposable;
-				}))
-				// complete sequence on OperationCanceledException, this is triggered by the cancellation token
-				.Catch<GraphQLResponse<TResponse>, OperationCanceledException>(exception =>
-					Observable.Empty<GraphQLResponse<TResponse>>())
-				// wrap results
-				.Select(response => new Tuple<GraphQLResponse<TResponse>, Exception>(response, null))
-				// do exception handling
-				.Catch<Tuple<GraphQLResponse<TResponse>, Exception>, Exception>(e => {
-					try {
-						if (exceptionHandler == null) {
-							// if the external handler is not set, propagate all exceptions except WebSocketExceptions
-							// this will ensure that the client tries to re-establish subscriptions on connection loss
-							if (!(e is WebSocketException)) throw e;
-						}
-						else {
-							// exceptions thrown by the handler will propagate to OnError()
-							exceptionHandler?.Invoke(e);
-						}
+        #region Send requests
 
-						// throw exception on the observable to be caught by Retry() or complete sequence if cancellation was requested
-						if (internalCancellationToken.IsCancellationRequested)
-							return Observable.Empty<Tuple<GraphQLResponse<TResponse>, Exception>>();
-						else {
-							Debug.WriteLine($"Catch handler thread id: {Thread.CurrentThread.ManagedThreadId}");
-							return Observable.Throw<Tuple<GraphQLResponse<TResponse>, Exception>>(e);
-						}
-					}
-					catch (Exception exception) {
-						// wrap all other exceptions to be propagated behind retry
-						return Observable.Return(new Tuple<GraphQLResponse<TResponse>, Exception>(null, exception));
-					}
-				})
-				// attempt to recreate the websocket for rethrown exceptions
-				.Retry()
-				// unwrap and push results or throw wrapped exceptions
-				.SelectMany(t => {
-					Debug.WriteLine($"unwrap exception thread id: {Thread.CurrentThread.ManagedThreadId}");
-					// if the result contains an exception, throw it on the observable
-					if (t.Item2 != null)
-						return Observable.Throw<GraphQLResponse<TResponse>>(t.Item2);
+        /// <summary>
+        /// Create a new subscription stream
+        /// </summary>
+        /// <typeparam name="TResponse">the response type</typeparam>
+        /// <param name="request">the <see cref="GraphQLRequest"/> to start the subscription</param>
+        /// <param name="exceptionHandler">Optional: exception handler for handling exceptions within the receive pipeline</param>
+        /// <returns>a <see cref="IObservable{TResponse}"/> which represents the subscription</returns>
+        public IObservable<GraphQLResponse<TResponse>> CreateSubscriptionStream<TResponse>(GraphQLRequest request, Action<Exception> exceptionHandler = null)
+        {
+            return Observable.Defer(() =>
+                Observable.Create<GraphQLResponse<TResponse>>(async observer =>
+                {
+                    Debug.WriteLine($"Create observable thread id: {Thread.CurrentThread.ManagedThreadId}");
+                    await client.Options.PreprocessRequest(request, client);
+                    var startRequest = new GraphQLWebSocketRequest
+                    {
+                        Id = Guid.NewGuid().ToString("N"),
+                        Type = GraphQLWebSocketMessageType.GQL_START,
+                        Payload = request
+                    };
+                    var closeRequest = new GraphQLWebSocketRequest
+                    {
+                        Id = startRequest.Id,
+                        Type = GraphQLWebSocketMessageType.GQL_STOP
+                    };
+                    var initRequest = new GraphQLWebSocketRequest
+                    {
+                        Id = startRequest.Id,
+                        Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
+                    };
 
-					return t.Item1 == null
-						? Observable.Empty<GraphQLResponse<TResponse>>()
-						: Observable.Return(t.Item1);
-				})
-				// transform to hot observable and auto-connect
-				.Publish().RefCount();
-		}
+                    var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>
+                        IncomingMessageStream
+                            // ignore null values and messages for other requests
+                            .Where(response => response != null && response.Id == startRequest.Id)
+                            .Subscribe(response =>
+                            {
+                                // terminate the sequence when a 'complete' message is received
+                                if (response.Type == GraphQLWebSocketMessageType.GQL_COMPLETE)
+                                {
+                                    Debug.WriteLine($"received 'complete' message on subscription {startRequest.Id}");
+                                    o.OnCompleted();
+                                    return;
+                                }
 
-		/// <summary>
-		/// Send a regular GraphQL request (query, mutation) via websocket
-		/// </summary>
-		/// <typeparam name="TResponse">the response type</typeparam>
-		/// <param name="request">the <see cref="GraphQLRequest"/> to send</param>
-		/// <param name="cancellationToken">the token to cancel the request</param>
-		/// <returns></returns>
-		public Task<GraphQLResponse<TResponse>> SendRequest<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default) {
-			return Observable.Create<GraphQLResponse<TResponse>>(async observer => {
-				await client.Options.PreprocessRequest(request, client);
-				var websocketRequest = new GraphQLWebSocketRequest {
-					Id = Guid.NewGuid().ToString("N"),
-					Type = GraphQLWebSocketMessageType.GQL_START,
-					Payload = request
-				};
-				var observable = IncomingMessageStream
-					.Where(response => response != null && response.Id == websocketRequest.Id)
-					.TakeUntil(response => response.Type == GraphQLWebSocketMessageType.GQL_COMPLETE)
-					.Select(response => {
-						Debug.WriteLine($"received response for request {websocketRequest.Id}");
-						var typedResponse =
-							client.Options.JsonSerializer.DeserializeToWebsocketResponse<TResponse>(
-								response.MessageBytes);
-						return typedResponse.Payload;
-					});
+                                // post the GraphQLResponse to the stream (even if a GraphQL error occurred)
+                                Debug.WriteLine($"received payload on subscription {startRequest.Id} (thread {Thread.CurrentThread.ManagedThreadId})");
+                                var typedResponse =
+                                    client.Options.JsonSerializer.DeserializeToWebsocketResponse<TResponse>(
+                                        response.MessageBytes);
+                                o.OnNext(typedResponse.Payload);
 
-				try {
-					// initialize websocket (completes immediately if socket is already open)
-					await InitializeWebSocket();
-				}
-				catch (Exception e) {
-					// subscribe observer to failed observable
-					return Observable.Throw<GraphQLResponse<TResponse>>(e).Subscribe(observer);
-				}
+                                // in case of a GraphQL error, terminate the sequence after the response has been posted
+                                if (response.Type == GraphQLWebSocketMessageType.GQL_ERROR)
+                                {
+                                    Debug.WriteLine($"terminating subscription {startRequest.Id} because of a GraphQL error");
+                                    o.OnCompleted();
+                                }
+                            },
+                                e =>
+                                {
+                                    Debug.WriteLine($"response stream for subscription {startRequest.Id} failed: {e}");
+                                    o.OnError(e);
+                                },
+                                () =>
+                                {
+                                    Debug.WriteLine($"response stream for subscription {startRequest.Id} completed");
+                                    o.OnCompleted();
+                                })
+                    );
 
-				var disposable = new CompositeDisposable(
-					observable.Subscribe(observer)
-				);
+                    try
+                    {
+                        // initialize websocket (completes immediately if socket is already open)
+                        await InitializeWebSocket();
+                    }
+                    catch (Exception e)
+                    {
+                        // subscribe observer to failed observable
+                        return Observable.Throw<GraphQLResponse<TResponse>>(e).Subscribe(observer);
+                    }
 
-				Debug.WriteLine($"submitting request {websocketRequest.Id}");
-				// send request
-				try {
-					await QueueWebSocketRequest(websocketRequest);
-				}
-				catch (Exception e) {
-					Console.WriteLine(e);
-					throw;
-				}
+                    var disposable = new CompositeDisposable(
+                        observable.Subscribe(observer),
+                        Disposable.Create(async () =>
+                        {
+                            // only try to send close request on open websocket
+                            if (WebSocketState != WebSocketState.Open)
+                                return;
 
-				return disposable;
-			})
-			// complete sequence on OperationCanceledException, this is triggered by the cancellation token
-			.Catch<GraphQLResponse<TResponse>, OperationCanceledException>(exception =>
-				Observable.Empty<GraphQLResponse<TResponse>>())
-			.FirstAsync()
-			.ToTask(cancellationToken);
-		}
+                            try
+                            {
+                                Debug.WriteLine($"sending close message on subscription {startRequest.Id}");
+                                await QueueWebSocketRequest(closeRequest);
+                            }
+                            // do not break on disposing
+                            catch (OperationCanceledException) { }
+                        })
+                    );
 
-		private Task QueueWebSocketRequest(GraphQLWebSocketRequest request) {
-			requestSubject.OnNext(request);
-			return request.SendTask();
-		}
+                    // send connection init
+                    Debug.WriteLine($"sending connection init on subscription {startRequest.Id}");
+                    try
+                    {
+                        await QueueWebSocketRequest(initRequest);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        throw;
+                    }
 
-		private async Task SendWebSocketRequest(GraphQLWebSocketRequest request) {
-			try {
-				if (internalCancellationToken.IsCancellationRequested) {
-					request.SendCanceled();
-					return;
-				}
+                    Debug.WriteLine($"sending initial message on subscription {startRequest.Id}");
+                    // send subscription request
+                    try
+                    {
+                        await QueueWebSocketRequest(startRequest);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        throw;
+                    }
 
-				await InitializeWebSocket();
-				var requestBytes = Options.JsonSerializer.SerializeToBytes(request);
-				await this.clientWebSocket.SendAsync(
-					new ArraySegment<byte>(requestBytes),
-					WebSocketMessageType.Text,
-					true,
-					internalCancellationToken);
-				request.SendCompleted();
-			}
-			catch (Exception e) {
-				request.SendFailed(e);
-			}
-		}
+                    return disposable;
+                }))
+                // complete sequence on OperationCanceledException, this is triggered by the cancellation token
+                .Catch<GraphQLResponse<TResponse>, OperationCanceledException>(exception =>
+                    Observable.Empty<GraphQLResponse<TResponse>>())
+                // wrap results
+                .Select(response => new Tuple<GraphQLResponse<TResponse>, Exception>(response, null))
+                // do exception handling
+                .Catch<Tuple<GraphQLResponse<TResponse>, Exception>, Exception>(e =>
+                {
+                    try
+                    {
+                        if (exceptionHandler == null)
+                        {
+                            // if the external handler is not set, propagate all exceptions except WebSocketExceptions
+                            // this will ensure that the client tries to re-establish subscriptions on connection loss
+                            if (!(e is WebSocketException))
+                                throw e;
+                        }
+                        else
+                        {
+                            // exceptions thrown by the handler will propagate to OnError()
+                            exceptionHandler?.Invoke(e);
+                        }
 
-		#endregion
-		
-		public Task InitializeWebSocket() {
-			// do not attempt to initialize if cancellation is requested
-			if (Completion != null)
-				throw new OperationCanceledException();
+                        // throw exception on the observable to be caught by Retry() or complete sequence if cancellation was requested
+                        if (internalCancellationToken.IsCancellationRequested)
+                            return Observable.Empty<Tuple<GraphQLResponse<TResponse>, Exception>>();
+                        else
+                        {
+                            Debug.WriteLine($"Catch handler thread id: {Thread.CurrentThread.ManagedThreadId}");
+                            return Observable.Throw<Tuple<GraphQLResponse<TResponse>, Exception>>(e);
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        // wrap all other exceptions to be propagated behind retry
+                        return Observable.Return(new Tuple<GraphQLResponse<TResponse>, Exception>(null, exception));
+                    }
+                })
+                // attempt to recreate the websocket for rethrown exceptions
+                .Retry()
+                // unwrap and push results or throw wrapped exceptions
+                .SelectMany(t =>
+                {
+                    Debug.WriteLine($"unwrap exception thread id: {Thread.CurrentThread.ManagedThreadId}");
+                    // if the result contains an exception, throw it on the observable
+                    if (t.Item2 != null)
+                        return Observable.Throw<GraphQLResponse<TResponse>>(t.Item2);
 
-			lock (initializeLock) {
-				// if an initialization task is already running, return that
-				if (initializeWebSocketTask != null &&
-				   !initializeWebSocketTask.IsFaulted &&
-				   !initializeWebSocketTask.IsCompleted)
-					return initializeWebSocketTask;
+                    return t.Item1 == null
+                        ? Observable.Empty<GraphQLResponse<TResponse>>()
+                        : Observable.Return(t.Item1);
+                })
+                // transform to hot observable and auto-connect
+                .Publish().RefCount();
+        }
 
-				// if the websocket is open, return a completed task
-				if (clientWebSocket != null && clientWebSocket.State == WebSocketState.Open)
-					return Task.CompletedTask;
+        /// <summary>
+        /// Send a regular GraphQL request (query, mutation) via websocket
+        /// </summary>
+        /// <typeparam name="TResponse">the response type</typeparam>
+        /// <param name="request">the <see cref="GraphQLRequest"/> to send</param>
+        /// <param name="cancellationToken">the token to cancel the request</param>
+        /// <returns></returns>
+        public Task<GraphQLResponse<TResponse>> SendRequest<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default)
+        {
+            return Observable.Create<GraphQLResponse<TResponse>>(async observer =>
+            {
+                await client.Options.PreprocessRequest(request, client);
+                var websocketRequest = new GraphQLWebSocketRequest
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    Type = GraphQLWebSocketMessageType.GQL_START,
+                    Payload = request
+                };
+                var observable = IncomingMessageStream
+                    .Where(response => response != null && response.Id == websocketRequest.Id)
+                    .TakeUntil(response => response.Type == GraphQLWebSocketMessageType.GQL_COMPLETE)
+                    .Select(response =>
+                    {
+                        Debug.WriteLine($"received response for request {websocketRequest.Id}");
+                        var typedResponse =
+                            client.Options.JsonSerializer.DeserializeToWebsocketResponse<TResponse>(
+                                response.MessageBytes);
+                        return typedResponse.Payload;
+                    });
 
-				// else (re-)create websocket and connect
-				clientWebSocket?.Dispose();
+                try
+                {
+                    // initialize websocket (completes immediately if socket is already open)
+                    await InitializeWebSocket();
+                }
+                catch (Exception e)
+                {
+                    // subscribe observer to failed observable
+                    return Observable.Throw<GraphQLResponse<TResponse>>(e).Subscribe(observer);
+                }
+
+                var disposable = new CompositeDisposable(
+                    observable.Subscribe(observer)
+                );
+
+                Debug.WriteLine($"submitting request {websocketRequest.Id}");
+                // send request
+                try
+                {
+                    await QueueWebSocketRequest(websocketRequest);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw;
+                }
+
+                return disposable;
+            })
+            // complete sequence on OperationCanceledException, this is triggered by the cancellation token
+            .Catch<GraphQLResponse<TResponse>, OperationCanceledException>(exception =>
+                Observable.Empty<GraphQLResponse<TResponse>>())
+            .FirstAsync()
+            .ToTask(cancellationToken);
+        }
+
+        private Task QueueWebSocketRequest(GraphQLWebSocketRequest request)
+        {
+            requestSubject.OnNext(request);
+            return request.SendTask();
+        }
+
+        private async Task SendWebSocketRequest(GraphQLWebSocketRequest request)
+        {
+            try
+            {
+                if (internalCancellationToken.IsCancellationRequested)
+                {
+                    request.SendCanceled();
+                    return;
+                }
+
+                await InitializeWebSocket();
+                var requestBytes = Options.JsonSerializer.SerializeToBytes(request);
+                await this.clientWebSocket.SendAsync(
+                    new ArraySegment<byte>(requestBytes),
+                    WebSocketMessageType.Text,
+                    true,
+                    internalCancellationToken);
+                request.SendCompleted();
+            }
+            catch (Exception e)
+            {
+                request.SendFailed(e);
+            }
+        }
+
+        #endregion
+
+        public Task InitializeWebSocket()
+        {
+            // do not attempt to initialize if cancellation is requested
+            if (Completion != null)
+                throw new OperationCanceledException();
+
+            lock (initializeLock)
+            {
+                // if an initialization task is already running, return that
+                if (initializeWebSocketTask != null &&
+                   !initializeWebSocketTask.IsFaulted &&
+                   !initializeWebSocketTask.IsCompleted)
+                    return initializeWebSocketTask;
+
+                // if the websocket is open, return a completed task
+                if (clientWebSocket != null && clientWebSocket.State == WebSocketState.Open)
+                    return Task.CompletedTask;
+
+                // else (re-)create websocket and connect
+                clientWebSocket?.Dispose();
 
 #if NETFRAMEWORK
 				// fix websocket not supported on win 7 using
@@ -368,212 +413,236 @@ namespace GraphQL.Client.Http.Websocket {
 						throw new NotSupportedException($"unknown websocket type {clientWebSocket.GetType().Name}");
 				}
 #else
-				clientWebSocket = new ClientWebSocket();
-				clientWebSocket.Options.AddSubProtocol("graphql-ws");
-				clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
-				clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
+                clientWebSocket = new ClientWebSocket();
+                clientWebSocket.Options.AddSubProtocol("graphql-ws");
+                clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
+                clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
 #endif
-				return initializeWebSocketTask = ConnectAsync(internalCancellationToken);
-			}
-		}
+                return initializeWebSocketTask = ConnectAsync(internalCancellationToken);
+            }
+        }
 
-		private async Task ConnectAsync(CancellationToken token) {
-			try {
-				await BackOff();
-				stateSubject.OnNext(GraphQLWebsocketConnectionState.Connecting);
-				Debug.WriteLine($"opening websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})");
-				await clientWebSocket.ConnectAsync(webSocketUri, token);
-				stateSubject.OnNext(GraphQLWebsocketConnectionState.Connected);
-				Debug.WriteLine($"connection established on websocket {clientWebSocket.GetHashCode()}, invoking Options.OnWebsocketConnected()");
-				await (Options.OnWebsocketConnected?.Invoke(client) ?? Task.CompletedTask);
-				Debug.WriteLine($"invoking Options.OnWebsocketConnected() on websocket {clientWebSocket.GetHashCode()}");
-				connectionAttempt = 1;
+        private async Task ConnectAsync(CancellationToken token)
+        {
+            try
+            {
+                await BackOff();
+                stateSubject.OnNext(GraphQLWebsocketConnectionState.Connecting);
+                Debug.WriteLine($"opening websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})");
+                await clientWebSocket.ConnectAsync(webSocketUri, token);
+                stateSubject.OnNext(GraphQLWebsocketConnectionState.Connected);
+                Debug.WriteLine($"connection established on websocket {clientWebSocket.GetHashCode()}, invoking Options.OnWebsocketConnected()");
+                await (Options.OnWebsocketConnected?.Invoke(client) ?? Task.CompletedTask);
+                Debug.WriteLine($"invoking Options.OnWebsocketConnected() on websocket {clientWebSocket.GetHashCode()}");
+                connectionAttempt = 1;
 
-				// create receiving observable
-				incomingMessages = Observable
-					.Defer(() => GetReceiveTask().ToObservable().ObserveOn(receiveLoopScheduler))
-					.Repeat()
-					// complete sequence on OperationCanceledException, this is triggered by the cancellation token on disposal
-					.Catch<WebsocketMessageWrapper, OperationCanceledException>(exception => Observable.Empty<WebsocketMessageWrapper>())
-					.Publish();
+                // create receiving observable
+                incomingMessages = Observable
+                    .Defer(() => GetReceiveTask().ToObservable().ObserveOn(receiveLoopScheduler))
+                    .Repeat()
+                    // complete sequence on OperationCanceledException, this is triggered by the cancellation token on disposal
+                    .Catch<WebsocketMessageWrapper, OperationCanceledException>(exception => Observable.Empty<WebsocketMessageWrapper>())
+                    .Publish();
 
-				// subscribe maintenance
-				var maintenanceSubscription = incomingMessages.Subscribe(_ => { }, ex => {
-						Debug.WriteLine($"incoming message stream {incomingMessages.GetHashCode()} received an error: {ex}");
-						exceptionSubject.OnNext(ex);
-						incomingMessagesConnection?.Dispose();
-						stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
-					},
-					() => {
-						Debug.WriteLine($"incoming message stream {incomingMessages.GetHashCode()} completed");
-						incomingMessagesConnection?.Dispose();
-						stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
-					});
+                // subscribe maintenance
+                var maintenanceSubscription = incomingMessages.Subscribe(_ => { }, ex =>
+                {
+                    Debug.WriteLine($"incoming message stream {incomingMessages.GetHashCode()} received an error: {ex}");
+                    exceptionSubject.OnNext(ex);
+                    incomingMessagesConnection?.Dispose();
+                    stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
+                },
+                    () =>
+                    {
+                        Debug.WriteLine($"incoming message stream {incomingMessages.GetHashCode()} completed");
+                        incomingMessagesConnection?.Dispose();
+                        stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
+                    });
 
 
-				// connect observable
-				var connection = incomingMessages.Connect();
-				Debug.WriteLine($"new incoming message stream {incomingMessages.GetHashCode()} created");
+                // connect observable
+                var connection = incomingMessages.Connect();
+                Debug.WriteLine($"new incoming message stream {incomingMessages.GetHashCode()} created");
 
-				incomingMessagesConnection = new CompositeDisposable(maintenanceSubscription, connection);
-			}
-			catch (Exception e) {
-				stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
-				exceptionSubject.OnNext(e);
-				throw;
-			}
-		}
+                incomingMessagesConnection = new CompositeDisposable(maintenanceSubscription, connection);
+            }
+            catch (Exception e)
+            {
+                stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
+                exceptionSubject.OnNext(e);
+                throw;
+            }
+        }
 
-		/// <summary>
-		/// delay the next connection attempt using <see cref="GraphQLHttpClientOptions.BackOffStrategy"/>
-		/// </summary>
-		/// <returns></returns>
-		private Task BackOff() {
-			connectionAttempt++;
+        /// <summary>
+        /// delay the next connection attempt using <see cref="GraphQLHttpClientOptions.BackOffStrategy"/>
+        /// </summary>
+        /// <returns></returns>
+        private Task BackOff()
+        {
+            connectionAttempt++;
 
-			if (connectionAttempt == 1) return Task.CompletedTask;
+            if (connectionAttempt == 1)
+                return Task.CompletedTask;
 
-			var delay = Options.BackOffStrategy?.Invoke(connectionAttempt - 1) ?? TimeSpan.FromSeconds(5);
-			Debug.WriteLine($"connection attempt #{connectionAttempt}, backing off for {delay.TotalSeconds} s");
-			return Task.Delay(delay, internalCancellationToken);
-		}
+            var delay = Options.BackOffStrategy?.Invoke(connectionAttempt - 1) ?? TimeSpan.FromSeconds(5);
+            Debug.WriteLine($"connection attempt #{connectionAttempt}, backing off for {delay.TotalSeconds} s");
+            return Task.Delay(delay, internalCancellationToken);
+        }
 
-		private IObservable<WebsocketMessageWrapper> GetMessageStream() {
-			return Observable.Using(() => new EventLoopScheduler(), scheduler =>
-				Observable.Create<WebsocketMessageWrapper>(async observer => {
-					// make sure the websocket ist connected
-					await InitializeWebSocket();
-					// subscribe observer to message stream
-					var subscription = new CompositeDisposable(incomingMessages.ObserveOn(scheduler).Subscribe(observer));
-					// register the observer's OnCompleted method with the cancellation token to complete the sequence on disposal
-					subscription.Add(internalCancellationTokenSource.Token.Register(observer.OnCompleted));
+        private IObservable<WebsocketMessageWrapper> GetMessageStream()
+        {
+            return Observable.Using(() => new EventLoopScheduler(), scheduler =>
+                Observable.Create<WebsocketMessageWrapper>(async observer =>
+                {
+                    // make sure the websocket ist connected
+                    await InitializeWebSocket();
+                    // subscribe observer to message stream
+                    var subscription = new CompositeDisposable(incomingMessages.ObserveOn(scheduler).Subscribe(observer));
+                    // register the observer's OnCompleted method with the cancellation token to complete the sequence on disposal
+                    subscription.Add(internalCancellationTokenSource.Token.Register(observer.OnCompleted));
 
-					// add some debug output
-					var hashCode = subscription.GetHashCode();
-					subscription.Add(Disposable.Create(() => {
-						Debug.WriteLine($"incoming message subscription {hashCode} disposed");
-					}));
-					Debug.WriteLine($"new incoming message subscription {hashCode} created");
+                    // add some debug output
+                    var hashCode = subscription.GetHashCode();
+                    subscription.Add(Disposable.Create(() =>
+                    {
+                        Debug.WriteLine($"incoming message subscription {hashCode} disposed");
+                    }));
+                    Debug.WriteLine($"new incoming message subscription {hashCode} created");
 
-					return subscription;
-				}));
-		}
+                    return subscription;
+                }));
+        }
 
-		private Task<WebsocketMessageWrapper> receiveAsyncTask = null;
-		private readonly object receiveTaskLocker = new object();
-		/// <summary>
-		/// wrapper method to pick up the existing request task if already running
-		/// </summary>
-		/// <returns></returns>
-		private Task<WebsocketMessageWrapper> GetReceiveTask() {
-			lock (receiveTaskLocker) {
-				internalCancellationToken.ThrowIfCancellationRequested();
-				if (receiveAsyncTask == null ||
-					receiveAsyncTask.IsFaulted ||
-					receiveAsyncTask.IsCompleted)
-					receiveAsyncTask = ReceiveWebsocketMessagesAsync();
-			}
+        private Task<WebsocketMessageWrapper> receiveAsyncTask = null;
+        private readonly object receiveTaskLocker = new object();
+        /// <summary>
+        /// wrapper method to pick up the existing request task if already running
+        /// </summary>
+        /// <returns></returns>
+        private Task<WebsocketMessageWrapper> GetReceiveTask()
+        {
+            lock (receiveTaskLocker)
+            {
+                internalCancellationToken.ThrowIfCancellationRequested();
+                if (receiveAsyncTask == null ||
+                    receiveAsyncTask.IsFaulted ||
+                    receiveAsyncTask.IsCompleted)
+                    receiveAsyncTask = ReceiveWebsocketMessagesAsync();
+            }
 
-			return receiveAsyncTask;
-		}
+            return receiveAsyncTask;
+        }
 
-		/// <summary>
-		/// read a single message from the websocket
-		/// </summary>
-		/// <returns></returns>
-		private async Task<WebsocketMessageWrapper> ReceiveWebsocketMessagesAsync() {
-			internalCancellationToken.ThrowIfCancellationRequested();
+        /// <summary>
+        /// read a single message from the websocket
+        /// </summary>
+        /// <returns></returns>
+        private async Task<WebsocketMessageWrapper> ReceiveWebsocketMessagesAsync()
+        {
+            internalCancellationToken.ThrowIfCancellationRequested();
 
-			try {
-				Debug.WriteLine($"waiting for data on websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
+            try
+            {
+                Debug.WriteLine($"waiting for data on websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
 
-				using var ms = new MemoryStream();
-				WebSocketReceiveResult webSocketReceiveResult = null;
-				do {
-					// cancellation is done implicitly via the close method
-					webSocketReceiveResult = await clientWebSocket.ReceiveAsync(buffer, CancellationToken.None);
-					ms.Write(buffer.Array, buffer.Offset, webSocketReceiveResult.Count);
-				}
-				while (!webSocketReceiveResult.EndOfMessage && !internalCancellationToken.IsCancellationRequested);
+                using var ms = new MemoryStream();
+                WebSocketReceiveResult webSocketReceiveResult = null;
+                do
+                {
+                    // cancellation is done implicitly via the close method
+                    webSocketReceiveResult = await clientWebSocket.ReceiveAsync(buffer, CancellationToken.None);
+                    ms.Write(buffer.Array, buffer.Offset, webSocketReceiveResult.Count);
+                }
+                while (!webSocketReceiveResult.EndOfMessage && !internalCancellationToken.IsCancellationRequested);
 
-				internalCancellationToken.ThrowIfCancellationRequested();
-				ms.Seek(0, SeekOrigin.Begin);
+                internalCancellationToken.ThrowIfCancellationRequested();
+                ms.Seek(0, SeekOrigin.Begin);
 
-				if (webSocketReceiveResult.MessageType == WebSocketMessageType.Text) {
-					var response = await Options.JsonSerializer.DeserializeToWebsocketResponseWrapperAsync(ms);
-					response.MessageBytes = ms.ToArray();
-					Debug.WriteLine($"{response.MessageBytes.Length} bytes received for id {response.Id} on websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
-					return response;
-				}
-				else {
-					throw new NotSupportedException("binary websocket messages are not supported");
-				}
-			}
-			catch (Exception e) {
-				Debug.WriteLine($"exception thrown while receiving websocket data: {e}");
-				throw;
-			}
-		}
+                if (webSocketReceiveResult.MessageType == WebSocketMessageType.Text)
+                {
+                    var response = await Options.JsonSerializer.DeserializeToWebsocketResponseWrapperAsync(ms);
+                    response.MessageBytes = ms.ToArray();
+                    Debug.WriteLine($"{response.MessageBytes.Length} bytes received for id {response.Id} on websocket {clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
+                    return response;
+                }
+                else
+                {
+                    throw new NotSupportedException("binary websocket messages are not supported");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine($"exception thrown while receiving websocket data: {e}");
+                throw;
+            }
+        }
 
-		private async Task CloseAsync() {
-			if (clientWebSocket == null)
-				return;
+        private async Task CloseAsync()
+        {
+            if (clientWebSocket == null)
+                return;
 
-			// don't attempt to close the websocket if it is in a failed state
-			if (this.clientWebSocket.State != WebSocketState.Open &&
-				this.clientWebSocket.State != WebSocketState.CloseReceived &&
-				this.clientWebSocket.State != WebSocketState.CloseSent) {
-				Debug.WriteLine($"websocket {clientWebSocket.GetHashCode()} state = {this.clientWebSocket.State}");
-				return;
-			}
+            // don't attempt to close the websocket if it is in a failed state
+            if (this.clientWebSocket.State != WebSocketState.Open &&
+                this.clientWebSocket.State != WebSocketState.CloseReceived &&
+                this.clientWebSocket.State != WebSocketState.CloseSent)
+            {
+                Debug.WriteLine($"websocket {clientWebSocket.GetHashCode()} state = {this.clientWebSocket.State}");
+                return;
+            }
 
-			Debug.WriteLine($"closing websocket {clientWebSocket.GetHashCode()}");
-			await this.clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-			stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
-		}
+            Debug.WriteLine($"closing websocket {clientWebSocket.GetHashCode()}");
+            await this.clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+            stateSubject.OnNext(GraphQLWebsocketConnectionState.Disconnected);
+        }
 
-		#region IDisposable
-		public void Dispose() => Complete();
+        #region IDisposable
+        public void Dispose() => Complete();
 
-		/// <summary>
-		/// Cancels the current operation, closes the websocket connection and disposes of internal resources.
-		/// </summary>
-		public void Complete() {
-			lock (completedLocker) {
-				if (Completion == null) Completion = CompleteAsync();
-			}
-		}
+        /// <summary>
+        /// Cancels the current operation, closes the websocket connection and disposes of internal resources.
+        /// </summary>
+        public void Complete()
+        {
+            lock (completedLocker)
+            {
+                if (Completion == null)
+                    Completion = CompleteAsync();
+            }
+        }
 
-		/// <summary>
-		/// Task to await the completion (a.k.a. disposal) of this websocket.
-		/// </summary> 
-		/// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
-		public Task Completion { get; private set; }
+        /// <summary>
+        /// Task to await the completion (a.k.a. disposal) of this websocket.
+        /// </summary> 
+        /// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
+        public Task Completion { get; private set; }
 
-		private readonly object completedLocker = new object();
-		private async Task CompleteAsync() {
-			Debug.WriteLine($"disposing websocket {clientWebSocket.GetHashCode()}...");
-			incomingMessagesConnection?.Dispose();
+        private readonly object completedLocker = new object();
+        private async Task CompleteAsync()
+        {
+            Debug.WriteLine($"disposing websocket {clientWebSocket.GetHashCode()}...");
+            incomingMessagesConnection?.Dispose();
 
-			if (!internalCancellationTokenSource.IsCancellationRequested)
-				internalCancellationTokenSource.Cancel();
-			
-			await CloseAsync();
-			requestSubscription?.Dispose();
-			clientWebSocket?.Dispose();
-			
-			stateSubject?.OnCompleted();
-			stateSubject?.Dispose();
+            if (!internalCancellationTokenSource.IsCancellationRequested)
+                internalCancellationTokenSource.Cancel();
 
-			exceptionSubject?.OnCompleted();
-			exceptionSubject?.Dispose();
-			internalCancellationTokenSource.Dispose();
+            await CloseAsync();
+            requestSubscription?.Dispose();
+            clientWebSocket?.Dispose();
 
-			sendLoopScheduler?.Dispose();
-			receiveLoopScheduler?.Dispose();
+            stateSubject?.OnCompleted();
+            stateSubject?.Dispose();
 
-			Debug.WriteLine($"websocket {clientWebSocket.GetHashCode()} disposed");
-		}
-#endregion
-	}
+            exceptionSubject?.OnCompleted();
+            exceptionSubject?.Dispose();
+            internalCancellationTokenSource.Dispose();
+
+            sendLoopScheduler?.Dispose();
+            receiveLoopScheduler?.Dispose();
+
+            Debug.WriteLine($"websocket {clientWebSocket.GetHashCode()} disposed");
+        }
+        #endregion
+    }
 }

--- a/src/GraphQL.Primitives/GraphQLError.cs
+++ b/src/GraphQL.Primitives/GraphQLError.cs
@@ -3,104 +3,121 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace GraphQL {
+namespace GraphQL
+{
 
-	/// <summary>
-	/// Represents a GraphQL Error of a GraphQL Query
-	/// </summary>
-	public class GraphQLError : IEquatable<GraphQLError?> {
+    /// <summary>
+    /// Represents a GraphQL Error of a GraphQL Query
+    /// </summary>
+    public class GraphQLError : IEquatable<GraphQLError?>
+    {
 
-		/// <summary>
-		/// The locations of the error
-		/// </summary>
-		[DataMember(Name = "locations")]
-		public GraphQLLocation[]? Locations { get; set; }
+        /// <summary>
+        /// The locations of the error
+        /// </summary>
+        [DataMember(Name = "locations")]
+        public GraphQLLocation[]? Locations { get; set; }
 
-		/// <summary>
-		/// The message of the error
-		/// </summary>
-		[DataMember(Name = "message")]
-		public string Message { get; set; }
+        /// <summary>
+        /// The message of the error
+        /// </summary>
+        [DataMember(Name = "message")]
+        public string Message { get; set; }
 
-		/// <summary>
-		/// The Path of the error
-		/// </summary>
-		[DataMember(Name = "path")]
-		public object[]? Path { get; set; }
+        /// <summary>
+        /// The Path of the error
+        /// </summary>
+        [DataMember(Name = "path")]
+        public object[]? Path { get; set; }
 
-		/// <summary>
-		/// The extensions of the error
-		/// </summary> 
-		[DataMember(Name = "extensions")]
-		public GraphQLExtensionsType? Extensions { get; set; }
+        /// <summary>
+        /// The extensions of the error
+        /// </summary> 
+        [DataMember(Name = "extensions")]
+        public GraphQLExtensionsType? Extensions { get; set; }
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="obj">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLError"/> and equals the value of the instance; otherwise, false</returns>
-		public override bool Equals(object? obj) =>
-			this.Equals(obj as GraphQLError);
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLError"/> and equals the value of the instance; otherwise, false</returns>
+        public override bool Equals(object? obj) =>
+            this.Equals(obj as GraphQLError);
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="other">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLError"/> and equals the value of the instance; otherwise, false</returns>
-		public bool Equals(GraphQLError? other) {
-			if (other == null) { return false; }
-			if (ReferenceEquals(this, other)) { return true; }
-			{
-				if (this.Locations != null && other.Locations != null) {
-					if (!this.Locations.SequenceEqual(other.Locations)) { return false; }
-				}
-				else if (this.Locations != null && other.Locations == null) { return false; }
-				else if (this.Locations == null && other.Locations != null) { return false; }
-			}
-			if (!EqualityComparer<string>.Default.Equals(this.Message, other.Message)) { return false; }
-			{
-				if (this.Path != null && other.Path != null) {
-					if (!this.Path.SequenceEqual(other.Path)) { return false; }
-				}
-				else if (this.Path != null && other.Path == null) { return false; }
-				else if (this.Path == null && other.Path != null) { return false; }
-			}
-			return true;
-		}
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="other">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLError"/> and equals the value of the instance; otherwise, false</returns>
+        public bool Equals(GraphQLError? other)
+        {
+            if (other == null)
+            { return false; }
+            if (ReferenceEquals(this, other))
+            { return true; }
+            {
+                if (this.Locations != null && other.Locations != null)
+                {
+                    if (!this.Locations.SequenceEqual(other.Locations))
+                    { return false; }
+                }
+                else if (this.Locations != null && other.Locations == null)
+                { return false; }
+                else if (this.Locations == null && other.Locations != null)
+                { return false; }
+            }
+            if (!EqualityComparer<string>.Default.Equals(this.Message, other.Message))
+            { return false; }
+            {
+                if (this.Path != null && other.Path != null)
+                {
+                    if (!this.Path.SequenceEqual(other.Path))
+                    { return false; }
+                }
+                else if (this.Path != null && other.Path == null)
+                { return false; }
+                else if (this.Path == null && other.Path != null)
+                { return false; }
+            }
+            return true;
+        }
 
-		/// <summary>
-		/// <inheritdoc cref="Object.GetHashCode"/>
-		/// </summary>
-		public override int GetHashCode() {
-			var hashCode = 0;
-			if (this.Locations != null) {
-				hashCode = hashCode ^ EqualityComparer<GraphQLLocation[]>.Default.GetHashCode(this.Locations);
-			}
-			hashCode = hashCode ^ EqualityComparer<string>.Default.GetHashCode(this.Message);
-			if (this.Path != null) {
-				hashCode = hashCode ^ EqualityComparer<dynamic>.Default.GetHashCode(this.Path);
-			}
-			return hashCode;
-		}
+        /// <summary>
+        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var hashCode = 0;
+            if (this.Locations != null)
+            {
+                hashCode = hashCode ^ EqualityComparer<GraphQLLocation[]>.Default.GetHashCode(this.Locations);
+            }
+            hashCode = hashCode ^ EqualityComparer<string>.Default.GetHashCode(this.Message);
+            if (this.Path != null)
+            {
+                hashCode = hashCode ^ EqualityComparer<dynamic>.Default.GetHashCode(this.Path);
+            }
+            return hashCode;
+        }
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLError"/> instances are equivalent
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLError"/> instance that is to the left of the equality operator</param>
-		/// <param name="right">The <see cref="GraphQLError"/> instance that is to the right of the equality operator</param>
-		/// <returns>true if left and right are equal; otherwise, false</returns>
-		public static bool operator ==(GraphQLError? left, GraphQLError? right) =>
-			EqualityComparer<GraphQLError?>.Default.Equals(left, right);
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLError"/> instances are equivalent
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLError"/> instance that is to the left of the equality operator</param>
+        /// <param name="right">The <see cref="GraphQLError"/> instance that is to the right of the equality operator</param>
+        /// <returns>true if left and right are equal; otherwise, false</returns>
+        public static bool operator ==(GraphQLError? left, GraphQLError? right) =>
+            EqualityComparer<GraphQLError?>.Default.Equals(left, right);
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLError"/> instances are not equal
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLError"/> instance that is to the left of the not equal operator</param>
-		/// <param name="right">The <see cref="GraphQLError"/> instance that is to the right of the not equal operator</param>
-		/// <returns>true if left and right are unequal; otherwise, false</returns>
-		public static bool operator !=(GraphQLError? left, GraphQLError? right) =>
-			!EqualityComparer<GraphQLError?>.Default.Equals(left, right);
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLError"/> instances are not equal
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLError"/> instance that is to the left of the not equal operator</param>
+        /// <param name="right">The <see cref="GraphQLError"/> instance that is to the right of the not equal operator</param>
+        /// <returns>true if left and right are unequal; otherwise, false</returns>
+        public static bool operator !=(GraphQLError? left, GraphQLError? right) =>
+            !EqualityComparer<GraphQLError?>.Default.Equals(left, right);
 
-	}
+    }
 
 }

--- a/src/GraphQL.Primitives/GraphQLError.cs
+++ b/src/GraphQL.Primitives/GraphQLError.cs
@@ -42,7 +42,7 @@ namespace GraphQL
         /// <param name="obj">The object to compare with this instance</param>
         /// <returns>true if obj is an instance of <see cref="GraphQLError"/> and equals the value of the instance; otherwise, false</returns>
         public override bool Equals(object? obj) =>
-            this.Equals(obj as GraphQLError);
+            Equals(obj as GraphQLError);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object
@@ -56,46 +56,46 @@ namespace GraphQL
             if (ReferenceEquals(this, other))
             { return true; }
             {
-                if (this.Locations != null && other.Locations != null)
+                if (Locations != null && other.Locations != null)
                 {
-                    if (!this.Locations.SequenceEqual(other.Locations))
+                    if (!Locations.SequenceEqual(other.Locations))
                     { return false; }
                 }
-                else if (this.Locations != null && other.Locations == null)
+                else if (Locations != null && other.Locations == null)
                 { return false; }
-                else if (this.Locations == null && other.Locations != null)
+                else if (Locations == null && other.Locations != null)
                 { return false; }
             }
-            if (!EqualityComparer<string>.Default.Equals(this.Message, other.Message))
+            if (!EqualityComparer<string>.Default.Equals(Message, other.Message))
             { return false; }
             {
-                if (this.Path != null && other.Path != null)
+                if (Path != null && other.Path != null)
                 {
-                    if (!this.Path.SequenceEqual(other.Path))
+                    if (!Path.SequenceEqual(other.Path))
                     { return false; }
                 }
-                else if (this.Path != null && other.Path == null)
+                else if (Path != null && other.Path == null)
                 { return false; }
-                else if (this.Path == null && other.Path != null)
+                else if (Path == null && other.Path != null)
                 { return false; }
             }
             return true;
         }
 
         /// <summary>
-        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// <inheritdoc cref="object.GetHashCode"/>
         /// </summary>
         public override int GetHashCode()
         {
             var hashCode = 0;
-            if (this.Locations != null)
+            if (Locations != null)
             {
-                hashCode = hashCode ^ EqualityComparer<GraphQLLocation[]>.Default.GetHashCode(this.Locations);
+                hashCode ^= EqualityComparer<GraphQLLocation[]>.Default.GetHashCode(Locations);
             }
-            hashCode = hashCode ^ EqualityComparer<string>.Default.GetHashCode(this.Message);
-            if (this.Path != null)
+            hashCode ^= EqualityComparer<string>.Default.GetHashCode(Message);
+            if (Path != null)
             {
-                hashCode = hashCode ^ EqualityComparer<dynamic>.Default.GetHashCode(this.Path);
+                hashCode ^= EqualityComparer<dynamic>.Default.GetHashCode(Path);
             }
             return hashCode;
         }

--- a/src/GraphQL.Primitives/GraphQLExtensionsType.cs
+++ b/src/GraphQL.Primitives/GraphQLExtensionsType.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 
-namespace GraphQL {
+namespace GraphQL
+{
 
-	/// <summary>
-	/// The GraphQL extensions type. Create a custom json converter for this class to customize your serializers behaviour
-	/// </summary>
-	public class GraphQLExtensionsType: Dictionary<string, object> { }
+    /// <summary>
+    /// The GraphQL extensions type. Create a custom json converter for this class to customize your serializers behaviour
+    /// </summary>
+    public class GraphQLExtensionsType : Dictionary<string, object> { }
 }

--- a/src/GraphQL.Primitives/GraphQLLocation.cs
+++ b/src/GraphQL.Primitives/GraphQLLocation.cs
@@ -25,7 +25,7 @@ namespace GraphQL
         /// </summary>
         /// <param name="obj">The object to compare with this instance</param>
         /// <returns>true if obj is an instance of <see cref="GraphQLLocation"/> and equals the value of the instance; otherwise, false</returns>
-        public override bool Equals(object obj) => this.Equals(obj as GraphQLLocation);
+        public override bool Equals(object obj) => Equals(obj as GraphQLLocation);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object
@@ -38,15 +38,15 @@ namespace GraphQL
             { return false; }
             if (ReferenceEquals(this, other))
             { return true; }
-            return EqualityComparer<uint>.Default.Equals(this.Column, other.Column) &&
-                EqualityComparer<uint>.Default.Equals(this.Line, other.Line);
+            return EqualityComparer<uint>.Default.Equals(Column, other.Column) &&
+                EqualityComparer<uint>.Default.Equals(Line, other.Line);
         }
 
         /// <summary>
-        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// <inheritdoc cref="object.GetHashCode"/>
         /// </summary>
         public override int GetHashCode() =>
-            this.Column.GetHashCode() ^ this.Line.GetHashCode();
+            Column.GetHashCode() ^ Line.GetHashCode();
 
         /// <summary>
         /// Tests whether two specified <see cref="GraphQLLocation"/> instances are equivalent

--- a/src/GraphQL.Primitives/GraphQLLocation.cs
+++ b/src/GraphQL.Primitives/GraphQLLocation.cs
@@ -1,66 +1,71 @@
 using System;
 using System.Collections.Generic;
 
-namespace GraphQL {
+namespace GraphQL
+{
 
-	/// <summary>
-	/// Represents a GraphQL Location of a GraphQL Query
-	/// </summary>
-	public sealed class GraphQLLocation : IEquatable<GraphQLLocation?> {
+    /// <summary>
+    /// Represents a GraphQL Location of a GraphQL Query
+    /// </summary>
+    public sealed class GraphQLLocation : IEquatable<GraphQLLocation?>
+    {
 
-		/// <summary>
-		/// The Column
-		/// </summary>
-		public uint Column { get; set; }
+        /// <summary>
+        /// The Column
+        /// </summary>
+        public uint Column { get; set; }
 
-		/// <summary>
-		/// The Line
-		/// </summary>
-		public uint Line { get; set; }
+        /// <summary>
+        /// The Line
+        /// </summary>
+        public uint Line { get; set; }
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="obj">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLLocation"/> and equals the value of the instance; otherwise, false</returns>
-		public override bool Equals(object obj) => this.Equals(obj as GraphQLLocation);
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLLocation"/> and equals the value of the instance; otherwise, false</returns>
+        public override bool Equals(object obj) => this.Equals(obj as GraphQLLocation);
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="other">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLLocation"/> and equals the value of the instance; otherwise, false</returns>
-		public bool Equals(GraphQLLocation? other) {
-			if (other == null) { return false; }
-			if (ReferenceEquals(this, other)) { return true; }
-			return EqualityComparer<uint>.Default.Equals(this.Column, other.Column) &&
-				EqualityComparer<uint>.Default.Equals(this.Line, other.Line);
-		}
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="other">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLLocation"/> and equals the value of the instance; otherwise, false</returns>
+        public bool Equals(GraphQLLocation? other)
+        {
+            if (other == null)
+            { return false; }
+            if (ReferenceEquals(this, other))
+            { return true; }
+            return EqualityComparer<uint>.Default.Equals(this.Column, other.Column) &&
+                EqualityComparer<uint>.Default.Equals(this.Line, other.Line);
+        }
 
-		/// <summary>
-		/// <inheritdoc cref="Object.GetHashCode"/>
-		/// </summary>
-		public override int GetHashCode() =>
-			this.Column.GetHashCode() ^ this.Line.GetHashCode();
+        /// <summary>
+        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// </summary>
+        public override int GetHashCode() =>
+            this.Column.GetHashCode() ^ this.Line.GetHashCode();
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLLocation"/> instances are equivalent
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLLocation"/> instance that is to the left of the equality operator</param>
-		/// <param name="right">The <see cref="GraphQLLocation"/> instance that is to the right of the equality operator</param>
-		/// <returns>true if left and right are equal; otherwise, false</returns>
-		public static bool operator ==(GraphQLLocation? left, GraphQLLocation? right) =>
-			EqualityComparer<GraphQLLocation?>.Default.Equals(left, right);
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLLocation"/> instances are equivalent
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLLocation"/> instance that is to the left of the equality operator</param>
+        /// <param name="right">The <see cref="GraphQLLocation"/> instance that is to the right of the equality operator</param>
+        /// <returns>true if left and right are equal; otherwise, false</returns>
+        public static bool operator ==(GraphQLLocation? left, GraphQLLocation? right) =>
+            EqualityComparer<GraphQLLocation?>.Default.Equals(left, right);
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLLocation"/> instances are not equal
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLLocation"/> instance that is to the left of the not equal operator</param>
-		/// <param name="right">The <see cref="GraphQLLocation"/> instance that is to the right of the not equal operator</param>
-		/// <returns>true if left and right are unequal; otherwise, false</returns>
-		public static bool operator !=(GraphQLLocation? left, GraphQLLocation? right) =>
-			!EqualityComparer<GraphQLLocation?>.Default.Equals(left, right);
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLLocation"/> instances are not equal
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLLocation"/> instance that is to the left of the not equal operator</param>
+        /// <param name="right">The <see cref="GraphQLLocation"/> instance that is to the right of the not equal operator</param>
+        /// <returns>true if left and right are unequal; otherwise, false</returns>
+        public static bool operator !=(GraphQLLocation? left, GraphQLLocation? right) =>
+            !EqualityComparer<GraphQLLocation?>.Default.Equals(left, right);
 
-	}
+    }
 
 }

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace GraphQL
 {
@@ -11,17 +10,17 @@ namespace GraphQL
     /// </summary>
     public class GraphQLRequest : Dictionary<string, object>, IEquatable<GraphQLRequest?>
     {
-        public const string OperationNameKey = "operationName";
-        public const string QueryKey = "query";
-        public const string VariablesKey = "variables";
+        public const string OPERATION_NAME_KEY = "operationName";
+        public const string QUERY_KEY = "query";
+        public const string VARIABLES_KEY = "variables";
 
         /// <summary>
         /// The Query
         /// </summary>
         public string Query
         {
-            get => ContainsKey(QueryKey) ? (string)this[QueryKey] : null;
-            set => this[QueryKey] = value;
+            get => ContainsKey(QUERY_KEY) ? (string)this[QUERY_KEY] : null;
+            set => this[QUERY_KEY] = value;
         }
 
         /// <summary>
@@ -29,8 +28,8 @@ namespace GraphQL
         /// </summary>
         public string? OperationName
         {
-            get => ContainsKey(OperationNameKey) ? (string)this[OperationNameKey] : null;
-            set => this[OperationNameKey] = value;
+            get => ContainsKey(OPERATION_NAME_KEY) ? (string)this[OPERATION_NAME_KEY] : null;
+            set => this[OPERATION_NAME_KEY] = value;
         }
 
         /// <summary>
@@ -38,8 +37,8 @@ namespace GraphQL
         /// </summary>
         public object? Variables
         {
-            get => ContainsKey(VariablesKey) ? this[VariablesKey] : null;
-            set => this[VariablesKey] = value;
+            get => ContainsKey(VARIABLES_KEY) ? this[VARIABLES_KEY] : null;
+            set => this[VARIABLES_KEY] = value;
         }
 
         public GraphQLRequest() { }
@@ -58,11 +57,11 @@ namespace GraphQL
         /// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
         public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
             if (ReferenceEquals(this, obj))
                 return true;
-            if (obj.GetType() != this.GetType())
+            if (obj.GetType() != GetType())
                 return false;
             return Equals((GraphQLRequest)obj);
         }
@@ -74,15 +73,15 @@ namespace GraphQL
         /// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
         public virtual bool Equals(GraphQLRequest? other)
         {
-            if (ReferenceEquals(null, other))
+            if (other is null)
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
-            return this.Count == other.Count && !this.Except(other).Any();
+            return Count == other.Count && !this.Except(other).Any();
         }
 
         /// <summary>
-        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// <inheritdoc cref="object.GetHashCode"/>
         /// </summary>
         public override int GetHashCode()
         {

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -3,99 +3,114 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace GraphQL {
+namespace GraphQL
+{
 
-	/// <summary>
-	/// A GraphQL request
-	/// </summary>
-	public class GraphQLRequest : Dictionary<string, object>, IEquatable<GraphQLRequest?> {
-		public const string OperationNameKey = "operationName";
-		public const string QueryKey = "query";
-		public const string VariablesKey = "variables";
+    /// <summary>
+    /// A GraphQL request
+    /// </summary>
+    public class GraphQLRequest : Dictionary<string, object>, IEquatable<GraphQLRequest?>
+    {
+        public const string OperationNameKey = "operationName";
+        public const string QueryKey = "query";
+        public const string VariablesKey = "variables";
 
-		/// <summary>
-		/// The Query
-		/// </summary>
-		public string Query {
-			get => ContainsKey(QueryKey) ? (string) this[QueryKey] : null;
-			set => this[QueryKey] = value;
-		}
+        /// <summary>
+        /// The Query
+        /// </summary>
+        public string Query
+        {
+            get => ContainsKey(QueryKey) ? (string)this[QueryKey] : null;
+            set => this[QueryKey] = value;
+        }
 
-		/// <summary>
-		/// The name of the Operation
-		/// </summary>
-		public string? OperationName {
-			get => ContainsKey(OperationNameKey) ? (string)this[OperationNameKey] : null;
-			set => this[OperationNameKey] = value;
-		}
+        /// <summary>
+        /// The name of the Operation
+        /// </summary>
+        public string? OperationName
+        {
+            get => ContainsKey(OperationNameKey) ? (string)this[OperationNameKey] : null;
+            set => this[OperationNameKey] = value;
+        }
 
-		/// <summary>
-		/// Represents the request variables
-		/// </summary>
-		public object? Variables {
-			get => ContainsKey(VariablesKey) ? this[VariablesKey] : null;
-			set => this[VariablesKey] = value;
-		}
+        /// <summary>
+        /// Represents the request variables
+        /// </summary>
+        public object? Variables
+        {
+            get => ContainsKey(VariablesKey) ? this[VariablesKey] : null;
+            set => this[VariablesKey] = value;
+        }
 
-		public GraphQLRequest() { }
+        public GraphQLRequest() { }
 
-		public GraphQLRequest(string query, object? variables = null, string? operationName = null) {
-			Query = query;
-			Variables = variables;
-			OperationName = operationName;
-		}
+        public GraphQLRequest(string query, object? variables = null, string? operationName = null)
+        {
+            Query = query;
+            Variables = variables;
+            OperationName = operationName;
+        }
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="obj">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
-		public override bool Equals(object? obj) {
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			if (obj.GetType() != this.GetType()) return false;
-			return Equals((GraphQLRequest)obj);
-		}
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((GraphQLRequest)obj);
+        }
 
-		/// <summary>
-		/// Returns a value that indicates whether this instance is equal to a specified object
-		/// </summary>
-		/// <param name="other">The object to compare with this instance</param>
-		/// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
-		public virtual bool Equals(GraphQLRequest? other) {
-			if (ReferenceEquals(null, other)) return false;
-			if (ReferenceEquals(this, other)) return true;
-			return this.Count == other.Count && !this.Except(other).Any();
-		}
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="other">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="GraphQLRequest"/> and equals the value of the instance; otherwise, false</returns>
+        public virtual bool Equals(GraphQLRequest? other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return this.Count == other.Count && !this.Except(other).Any();
+        }
 
-		/// <summary>
-		/// <inheritdoc cref="Object.GetHashCode"/>
-		/// </summary>
-		public override int GetHashCode() {
-			unchecked {
-				var hashCode = Query.GetHashCode();
-				hashCode = (hashCode * 397) ^ OperationName?.GetHashCode() ?? 0;
-				hashCode = (hashCode * 397) ^ Variables?.GetHashCode() ?? 0;
-				return hashCode;
-			}
-		}
+        /// <summary>
+        /// <inheritdoc cref="Object.GetHashCode"/>
+        /// </summary>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Query.GetHashCode();
+                hashCode = (hashCode * 397) ^ OperationName?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ Variables?.GetHashCode() ?? 0;
+                return hashCode;
+            }
+        }
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLRequest"/> instances are equivalent
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLRequest"/> instance that is to the left of the equality operator</param>
-		/// <param name="right">The <see cref="GraphQLRequest"/> instance that is to the right of the equality operator</param>
-		/// <returns>true if left and right are equal; otherwise, false</returns>
-		public static bool operator ==(GraphQLRequest? left, GraphQLRequest? right) => EqualityComparer<GraphQLRequest?>.Default.Equals(left, right);
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLRequest"/> instances are equivalent
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLRequest"/> instance that is to the left of the equality operator</param>
+        /// <param name="right">The <see cref="GraphQLRequest"/> instance that is to the right of the equality operator</param>
+        /// <returns>true if left and right are equal; otherwise, false</returns>
+        public static bool operator ==(GraphQLRequest? left, GraphQLRequest? right) => EqualityComparer<GraphQLRequest?>.Default.Equals(left, right);
 
-		/// <summary>
-		/// Tests whether two specified <see cref="GraphQLRequest"/> instances are not equal
-		/// </summary>
-		/// <param name="left">The <see cref="GraphQLRequest"/> instance that is to the left of the not equal operator</param>
-		/// <param name="right">The <see cref="GraphQLRequest"/> instance that is to the right of the not equal operator</param>
-		/// <returns>true if left and right are unequal; otherwise, false</returns>
-		public static bool operator !=(GraphQLRequest? left, GraphQLRequest? right) => !(left == right);
-	}
+        /// <summary>
+        /// Tests whether two specified <see cref="GraphQLRequest"/> instances are not equal
+        /// </summary>
+        /// <param name="left">The <see cref="GraphQLRequest"/> instance that is to the left of the not equal operator</param>
+        /// <param name="right">The <see cref="GraphQLRequest"/> instance that is to the right of the not equal operator</param>
+        /// <returns>true if left and right are unequal; otherwise, false</returns>
+        public static bool operator !=(GraphQLRequest? left, GraphQLRequest? right) => !(left == right);
+    }
 
 
 }

--- a/src/GraphQL.Primitives/GraphQLResponse.cs
+++ b/src/GraphQL.Primitives/GraphQLResponse.cs
@@ -3,73 +3,95 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace GraphQL {
+namespace GraphQL
+{
 
-	public class GraphQLResponse<T> : IEquatable<GraphQLResponse<T>?> {
+    public class GraphQLResponse<T> : IEquatable<GraphQLResponse<T>?>
+    {
 
-		[DataMember(Name = "data")]
-		public T Data { get; set; }
+        [DataMember(Name = "data")]
+        public T Data { get; set; }
 
-		[DataMember(Name = "errors")]
-		public GraphQLError[]? Errors { get; set; }
+        [DataMember(Name = "errors")]
+        public GraphQLError[]? Errors { get; set; }
 
-		[DataMember(Name = "extensions")]
-		public GraphQLExtensionsType? Extensions { get; set; }
+        [DataMember(Name = "extensions")]
+        public GraphQLExtensionsType? Extensions { get; set; }
 
-		public override bool Equals(object? obj) => this.Equals(obj as GraphQLResponse<T>);
+        public override bool Equals(object? obj) => this.Equals(obj as GraphQLResponse<T>);
 
-		public bool Equals(GraphQLResponse<T>? other) {
-			if (other == null) { return false; }
-			if (ReferenceEquals(this, other)) { return true; }
-			if (!EqualityComparer<T>.Default.Equals(this.Data, other.Data)) { return false; }
+        public bool Equals(GraphQLResponse<T>? other)
+        {
+            if (other == null)
+            { return false; }
+            if (ReferenceEquals(this, other))
+            { return true; }
+            if (!EqualityComparer<T>.Default.Equals(this.Data, other.Data))
+            { return false; }
 
-			if (this.Errors != null && other.Errors != null) {
-				if (!Enumerable.SequenceEqual(this.Errors, other.Errors)) { return false; }
-			}
-			else if (this.Errors != null && other.Errors == null) { return false; }
-			else if (this.Errors == null && other.Errors != null) { return false; }
+            if (this.Errors != null && other.Errors != null)
+            {
+                if (!Enumerable.SequenceEqual(this.Errors, other.Errors))
+                { return false; }
+            }
+            else if (this.Errors != null && other.Errors == null)
+            { return false; }
+            else if (this.Errors == null && other.Errors != null)
+            { return false; }
 
-			if (this.Extensions!= null && other.Extensions != null) {
-				if (!Enumerable.SequenceEqual(this.Extensions, other.Extensions)) { return false; }
-			}
-			else if (this.Extensions != null && other.Extensions == null) { return false; }
-			else if (this.Extensions == null && other.Extensions != null) { return false; }
+            if (this.Extensions != null && other.Extensions != null)
+            {
+                if (!Enumerable.SequenceEqual(this.Extensions, other.Extensions))
+                { return false; }
+            }
+            else if (this.Extensions != null && other.Extensions == null)
+            { return false; }
+            else if (this.Extensions == null && other.Extensions != null)
+            { return false; }
 
-			return true;
-		}
+            return true;
+        }
 
-		public override int GetHashCode() {
-			unchecked {
-				var hashCode = EqualityComparer<T>.Default.GetHashCode(this.Data);
-				{
-					if (this.Errors != null) {
-						foreach (var element in this.Errors) {
-							hashCode = (hashCode * 397) ^ EqualityComparer<GraphQLError?>.Default.GetHashCode(element);
-						}
-					}
-					else {
-						hashCode = (hashCode * 397) ^ 0;
-					}
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = EqualityComparer<T>.Default.GetHashCode(this.Data);
+                {
+                    if (this.Errors != null)
+                    {
+                        foreach (var element in this.Errors)
+                        {
+                            hashCode = (hashCode * 397) ^ EqualityComparer<GraphQLError?>.Default.GetHashCode(element);
+                        }
+                    }
+                    else
+                    {
+                        hashCode = (hashCode * 397) ^ 0;
+                    }
 
-					if (this.Extensions != null) {
-						foreach (var element in this.Extensions) {
-							hashCode = (hashCode * 397) ^ EqualityComparer<KeyValuePair<string,object>>.Default.GetHashCode(element);
-						}
-					}
-					else {
-						hashCode = (hashCode * 397) ^ 0;
-					}
-				}
-				return hashCode;
-			}
-		}
+                    if (this.Extensions != null)
+                    {
+                        foreach (var element in this.Extensions)
+                        {
+                            hashCode = (hashCode * 397) ^ EqualityComparer<KeyValuePair<string, object>>.Default.GetHashCode(element);
+                        }
+                    }
+                    else
+                    {
+                        hashCode = (hashCode * 397) ^ 0;
+                    }
+                }
+                return hashCode;
+            }
+        }
 
 
-		public static bool operator ==(GraphQLResponse<T>? response1, GraphQLResponse<T>? response2) => EqualityComparer<GraphQLResponse<T>?>.Default.Equals(response1, response2);
+        public static bool operator ==(GraphQLResponse<T>? response1, GraphQLResponse<T>? response2) => EqualityComparer<GraphQLResponse<T>?>.Default.Equals(response1, response2);
 
-		public static bool operator !=(GraphQLResponse<T>? response1, GraphQLResponse<T>? response2) => !(response1 == response2);
+        public static bool operator !=(GraphQLResponse<T>? response1, GraphQLResponse<T>? response2) => !(response1 == response2);
 
-	}
+    }
 
 
 

--- a/src/GraphQL.Primitives/GraphQLResponse.cs
+++ b/src/GraphQL.Primitives/GraphQLResponse.cs
@@ -18,7 +18,7 @@ namespace GraphQL
         [DataMember(Name = "extensions")]
         public GraphQLExtensionsType? Extensions { get; set; }
 
-        public override bool Equals(object? obj) => this.Equals(obj as GraphQLResponse<T>);
+        public override bool Equals(object? obj) => Equals(obj as GraphQLResponse<T>);
 
         public bool Equals(GraphQLResponse<T>? other)
         {
@@ -26,27 +26,27 @@ namespace GraphQL
             { return false; }
             if (ReferenceEquals(this, other))
             { return true; }
-            if (!EqualityComparer<T>.Default.Equals(this.Data, other.Data))
+            if (!EqualityComparer<T>.Default.Equals(Data, other.Data))
             { return false; }
 
-            if (this.Errors != null && other.Errors != null)
+            if (Errors != null && other.Errors != null)
             {
-                if (!Enumerable.SequenceEqual(this.Errors, other.Errors))
+                if (!Enumerable.SequenceEqual(Errors, other.Errors))
                 { return false; }
             }
-            else if (this.Errors != null && other.Errors == null)
+            else if (Errors != null && other.Errors == null)
             { return false; }
-            else if (this.Errors == null && other.Errors != null)
+            else if (Errors == null && other.Errors != null)
             { return false; }
 
-            if (this.Extensions != null && other.Extensions != null)
+            if (Extensions != null && other.Extensions != null)
             {
-                if (!Enumerable.SequenceEqual(this.Extensions, other.Extensions))
+                if (!Enumerable.SequenceEqual(Extensions, other.Extensions))
                 { return false; }
             }
-            else if (this.Extensions != null && other.Extensions == null)
+            else if (Extensions != null && other.Extensions == null)
             { return false; }
-            else if (this.Extensions == null && other.Extensions != null)
+            else if (Extensions == null && other.Extensions != null)
             { return false; }
 
             return true;
@@ -56,11 +56,11 @@ namespace GraphQL
         {
             unchecked
             {
-                var hashCode = EqualityComparer<T>.Default.GetHashCode(this.Data);
+                var hashCode = EqualityComparer<T>.Default.GetHashCode(Data);
                 {
-                    if (this.Errors != null)
+                    if (Errors != null)
                     {
-                        foreach (var element in this.Errors)
+                        foreach (var element in Errors)
                         {
                             hashCode = (hashCode * 397) ^ EqualityComparer<GraphQLError?>.Default.GetHashCode(element);
                         }
@@ -70,9 +70,9 @@ namespace GraphQL
                         hashCode = (hashCode * 397) ^ 0;
                     }
 
-                    if (this.Extensions != null)
+                    if (Extensions != null)
                     {
-                        foreach (var element in this.Extensions)
+                        foreach (var element in Extensions)
                         {
                             hashCode = (hashCode * 397) ^ EqualityComparer<KeyValuePair<string, object>>.Default.GetHashCode(element);
                         }

--- a/tests/GraphQL.Client.Serializer.Tests/BaseSerializeNoCamelCaseTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/BaseSerializeNoCamelCaseTest.cs
@@ -11,54 +11,62 @@ using GraphQL.Client.Tests.Common.Helpers;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace GraphQL.Client.Serializer.Tests {
-	public abstract class BaseSerializeNoCamelCaseTest {
+namespace GraphQL.Client.Serializer.Tests
+{
+    public abstract class BaseSerializeNoCamelCaseTest
+    {
 
-		public IGraphQLWebsocketJsonSerializer Serializer { get; }
-		public IGraphQLClient ChatClient { get; }
-		public IGraphQLClient StarWarsClient { get; }
+        public IGraphQLWebsocketJsonSerializer Serializer { get; }
+        public IGraphQLClient ChatClient { get; }
+        public IGraphQLClient StarWarsClient { get; }
 
-		protected BaseSerializeNoCamelCaseTest(IGraphQLWebsocketJsonSerializer serializer) {
-			Serializer = serializer;
-			ChatClient = GraphQLLocalExecutionClient.New(Common.GetChatSchema(), serializer);
-			StarWarsClient = GraphQLLocalExecutionClient.New(Common.GetStarWarsSchema(), serializer);
-		}
+        protected BaseSerializeNoCamelCaseTest(IGraphQLWebsocketJsonSerializer serializer)
+        {
+            Serializer = serializer;
+            ChatClient = GraphQLLocalExecutionClient.New(Common.GetChatSchema(), serializer);
+            StarWarsClient = GraphQLLocalExecutionClient.New(Common.GetStarWarsSchema(), serializer);
+        }
 
-		[Theory]
-		[ClassData(typeof(SerializeToStringTestData))]
-		public void SerializeToStringTest(string expectedJson, GraphQLRequest request) {
-			var json = Serializer.SerializeToString(request).RemoveWhitespace();
-			json.Should().Be(expectedJson.RemoveWhitespace());
-		}
+        [Theory]
+        [ClassData(typeof(SerializeToStringTestData))]
+        public void SerializeToStringTest(string expectedJson, GraphQLRequest request)
+        {
+            var json = Serializer.SerializeToString(request).RemoveWhitespace();
+            json.Should().Be(expectedJson.RemoveWhitespace());
+        }
 
-		[Theory]
-		[ClassData(typeof(SerializeToBytesTestData))]
-		public void SerializeToBytesTest(string expectedJson, GraphQLWebSocketRequest request) {
-			var json = Encoding.UTF8.GetString(Serializer.SerializeToBytes(request)).RemoveWhitespace();
-			json.Should().Be(expectedJson.RemoveWhitespace());
-		}
+        [Theory]
+        [ClassData(typeof(SerializeToBytesTestData))]
+        public void SerializeToBytesTest(string expectedJson, GraphQLWebSocketRequest request)
+        {
+            var json = Encoding.UTF8.GetString(Serializer.SerializeToBytes(request)).RemoveWhitespace();
+            json.Should().Be(expectedJson.RemoveWhitespace());
+        }
 
 
-		[Fact]
-		public async void WorksWithoutCamelCaseNamingStrategy() {
+        [Fact]
+        public async void WorksWithoutCamelCaseNamingStrategy()
+        {
 
-			const string message = "some random testing message";
-			var graphQLRequest = new GraphQLRequest(
-				@"mutation($input: MessageInputType){
+            const string message = "some random testing message";
+            var graphQLRequest = new GraphQLRequest(
+                @"mutation($input: MessageInputType){
 				  addMessage(message: $input){
 				    content
 				  }
 				}",
-				new {
-					input = new {
-						fromId = "2",
-						content = message,
-						sentAt = DateTime.Now
-					}
-				});
-			var response = await ChatClient.SendMutationAsync(graphQLRequest, () => new { addMessage = new { content = "" } });
+                new
+                {
+                    input = new
+                    {
+                        fromId = "2",
+                        content = message,
+                        sentAt = DateTime.Now
+                    }
+                });
+            var response = await ChatClient.SendMutationAsync(graphQLRequest, () => new { addMessage = new { content = "" } });
 
-			Assert.Equal(message, response.Data.addMessage.content);
-		}
-	}
+            Assert.Equal(message, response.Data.addMessage.content);
+        }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/BaseSerializeNoCamelCaseTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/BaseSerializeNoCamelCaseTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
 using GraphQL.Client.Abstractions;
@@ -8,7 +7,6 @@ using GraphQL.Client.LocalExecution;
 using GraphQL.Client.Serializer.Tests.TestData;
 using GraphQL.Client.Tests.Common;
 using GraphQL.Client.Tests.Common.Helpers;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace GraphQL.Client.Serializer.Tests

--- a/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using FluentAssertions;

--- a/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
@@ -19,70 +19,78 @@ namespace GraphQL.Client.Serializer.Tests
 {
     public abstract class BaseSerializerTest
     {
-	    public IGraphQLWebsocketJsonSerializer Serializer { get; }
-	    public IGraphQLClient ChatClient { get; }
-	    public IGraphQLClient StarWarsClient { get; }
+        public IGraphQLWebsocketJsonSerializer Serializer { get; }
+        public IGraphQLClient ChatClient { get; }
+        public IGraphQLClient StarWarsClient { get; }
 
-		protected BaseSerializerTest(IGraphQLWebsocketJsonSerializer serializer) {
-			Serializer = serializer;
-			ChatClient = GraphQLLocalExecutionClient.New(Common.GetChatSchema(), serializer);
-			StarWarsClient = GraphQLLocalExecutionClient.New(Common.GetStarWarsSchema(), serializer);
-		}
+        protected BaseSerializerTest(IGraphQLWebsocketJsonSerializer serializer)
+        {
+            Serializer = serializer;
+            ChatClient = GraphQLLocalExecutionClient.New(Common.GetChatSchema(), serializer);
+            StarWarsClient = GraphQLLocalExecutionClient.New(Common.GetStarWarsSchema(), serializer);
+        }
 
-		[Theory]
-		[ClassData(typeof(SerializeToStringTestData))]
-		public void SerializeToStringTest(string expectedJson, GraphQLRequest request) {
-			var json = Serializer.SerializeToString(request).RemoveWhitespace();
-			json.Should().BeEquivalentTo(expectedJson.RemoveWhitespace());
-		}
+        [Theory]
+        [ClassData(typeof(SerializeToStringTestData))]
+        public void SerializeToStringTest(string expectedJson, GraphQLRequest request)
+        {
+            var json = Serializer.SerializeToString(request).RemoveWhitespace();
+            json.Should().BeEquivalentTo(expectedJson.RemoveWhitespace());
+        }
 
-		[Theory]
-		[ClassData(typeof(SerializeToBytesTestData))]
-		public void SerializeToBytesTest(string expectedJson, GraphQLWebSocketRequest request) {
-			var json = Encoding.UTF8.GetString(Serializer.SerializeToBytes(request)).RemoveWhitespace();
-			json.Should().BeEquivalentTo(expectedJson.RemoveWhitespace());
-		}
+        [Theory]
+        [ClassData(typeof(SerializeToBytesTestData))]
+        public void SerializeToBytesTest(string expectedJson, GraphQLWebSocketRequest request)
+        {
+            var json = Encoding.UTF8.GetString(Serializer.SerializeToBytes(request)).RemoveWhitespace();
+            json.Should().BeEquivalentTo(expectedJson.RemoveWhitespace());
+        }
 
-		[Theory]
-		[ClassData(typeof(DeserializeResponseTestData))]
-		public async void DeserializeFromUtf8StreamTest(string json, GraphQLResponse<object> expectedResponse) {
-			var jsonBytes = Encoding.UTF8.GetBytes(json);
-			await using var ms = new MemoryStream(jsonBytes);
-			var response = await Serializer.DeserializeFromUtf8StreamAsync<GraphQLResponse<object>>(ms, CancellationToken.None);
+        [Theory]
+        [ClassData(typeof(DeserializeResponseTestData))]
+        public async void DeserializeFromUtf8StreamTest(string json, GraphQLResponse<object> expectedResponse)
+        {
+            var jsonBytes = Encoding.UTF8.GetBytes(json);
+            await using var ms = new MemoryStream(jsonBytes);
+            var response = await Serializer.DeserializeFromUtf8StreamAsync<GraphQLResponse<object>>(ms, CancellationToken.None);
 
-			response.Data.Should().BeEquivalentTo(expectedResponse.Data);
-			response.Errors.Should().Equal(expectedResponse.Errors);
+            response.Data.Should().BeEquivalentTo(expectedResponse.Data);
+            response.Errors.Should().Equal(expectedResponse.Errors);
 
-			if (expectedResponse.Extensions == null)
-				response.Extensions.Should().BeNull();
-			else {
-				foreach (var element in expectedResponse.Extensions) {
-					response.Extensions.Should().ContainKey(element.Key);
-					response.Extensions[element.Key].Should().BeEquivalentTo(element.Value);
-				}
-			}
-		}
+            if (expectedResponse.Extensions == null)
+                response.Extensions.Should().BeNull();
+            else
+            {
+                foreach (var element in expectedResponse.Extensions)
+                {
+                    response.Extensions.Should().ContainKey(element.Key);
+                    response.Extensions[element.Key].Should().BeEquivalentTo(element.Value);
+                }
+            }
+        }
 
-		[Fact]
-		public async void CanDeserializeExtensions() {
+        [Fact]
+        public async void CanDeserializeExtensions()
+        {
 
-			var response = await ChatClient.SendQueryAsync(new GraphQLRequest("query { extensionsTest }"),
-					() => new { extensionsTest = "" })
-				;
+            var response = await ChatClient.SendQueryAsync(new GraphQLRequest("query { extensionsTest }"),
+                    () => new { extensionsTest = "" })
+                ;
 
-			response.Errors.Should().NotBeNull();
-			response.Errors.Should().ContainSingle();
-			response.Errors[0].Extensions.Should().NotBeNull();
-			response.Errors[0].Extensions.Should().ContainKey("data");
+            response.Errors.Should().NotBeNull();
+            response.Errors.Should().ContainSingle();
+            response.Errors[0].Extensions.Should().NotBeNull();
+            response.Errors[0].Extensions.Should().ContainKey("data");
 
-			response.Errors[0].Extensions["data"].Should().BeEquivalentTo(ChatQuery.TestExtensions);
-		}
+            response.Errors[0].Extensions["data"].Should().BeEquivalentTo(ChatQuery.TestExtensions);
+        }
 
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void CanDoSerializationWithAnonymousTypes(int id, string name) {
-			var graphQLRequest = new GraphQLRequest(@"
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void CanDoSerializationWithAnonymousTypes(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				query Human($id: String!){
 					human(id: $id) {
 						name
@@ -94,21 +102,22 @@ namespace GraphQL.Client.Serializer.Tests
 				    name
 				  }
 				}",
-				new { id = id.ToString() },
-				"Human");
+                new { id = id.ToString() },
+                "Human");
 
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
 
-			Assert.Null(response.Errors);
-			Assert.Equal(name, response.Data.Human.Name);
-		}
+            Assert.Null(response.Errors);
+            Assert.Equal(name, response.Data.Human.Name);
+        }
 
-		[Fact]
-		public async void CanDoSerializationWithPredefinedTypes() {
-				const string message = "some random testing message";
-				var response = await ChatClient.AddMessageAsync(message);
+        [Fact]
+        public async void CanDoSerializationWithPredefinedTypes()
+        {
+            const string message = "some random testing message";
+            var response = await ChatClient.AddMessageAsync(message);
 
-				Assert.Equal(message, response.Data.AddMessage.Content);
-		}
-	}
+            Assert.Equal(message, response.Data.AddMessage.Content);
+        }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/NewtonsoftSerializerTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/NewtonsoftSerializerTest.cs
@@ -2,13 +2,16 @@ using System.Collections.Generic;
 using GraphQL.Client.Serializer.Newtonsoft;
 using Newtonsoft.Json;
 
-namespace GraphQL.Client.Serializer.Tests {
-	public class NewtonsoftSerializerTest : BaseSerializerTest {
-		public NewtonsoftSerializerTest() : base(new NewtonsoftJsonSerializer()) { }
-	}
+namespace GraphQL.Client.Serializer.Tests
+{
+    public class NewtonsoftSerializerTest : BaseSerializerTest
+    {
+        public NewtonsoftSerializerTest() : base(new NewtonsoftJsonSerializer()) { }
+    }
 
-	public class NewtonsoftSerializeNoCamelCaseTest : BaseSerializeNoCamelCaseTest {
-		public NewtonsoftSerializeNoCamelCaseTest()
-			: base(new NewtonsoftJsonSerializer(new JsonSerializerSettings())) { }
-	}
+    public class NewtonsoftSerializeNoCamelCaseTest : BaseSerializeNoCamelCaseTest
+    {
+        public NewtonsoftSerializeNoCamelCaseTest()
+            : base(new NewtonsoftJsonSerializer(new JsonSerializerSettings())) { }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/NewtonsoftSerializerTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/NewtonsoftSerializerTest.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using GraphQL.Client.Serializer.Newtonsoft;
 using Newtonsoft.Json;
 

--- a/tests/GraphQL.Client.Serializer.Tests/SystemTextJsonSerializerTests.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/SystemTextJsonSerializerTests.cs
@@ -1,13 +1,16 @@
 using System.Text.Json;
 using GraphQL.Client.Serializer.SystemTextJson;
 
-namespace GraphQL.Client.Serializer.Tests {
-	public class SystemTextJsonSerializerTests: BaseSerializerTest {
-		public SystemTextJsonSerializerTests() : base(new SystemTextJsonSerializer()) { }
-	}
+namespace GraphQL.Client.Serializer.Tests
+{
+    public class SystemTextJsonSerializerTests : BaseSerializerTest
+    {
+        public SystemTextJsonSerializerTests() : base(new SystemTextJsonSerializer()) { }
+    }
 
-	public class SystemTextJsonSerializeNoCamelCaseTest : BaseSerializeNoCamelCaseTest {
-		public SystemTextJsonSerializeNoCamelCaseTest()
-			: base(new SystemTextJsonSerializer(new JsonSerializerOptions().SetupImmutableConverter())) { }
-	}
+    public class SystemTextJsonSerializeNoCamelCaseTest : BaseSerializeNoCamelCaseTest
+    {
+        public SystemTextJsonSerializeNoCamelCaseTest()
+            : base(new SystemTextJsonSerializer(new JsonSerializerOptions().SetupImmutableConverter())) { }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/DeserializeResponseTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/DeserializeResponseTestData.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 
 namespace GraphQL.Client.Serializer.Tests.TestData
 {
@@ -41,10 +39,6 @@ namespace GraphQL.Client.Serializer.Tests.TestData
             };
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/DeserializeResponseTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/DeserializeResponseTestData.cs
@@ -3,44 +3,48 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
-namespace GraphQL.Client.Serializer.Tests.TestData {
-	public class DeserializeResponseTestData : IEnumerable<object[]> {
-		public IEnumerator<object[]> GetEnumerator() {
-			// object array structure:
-			// [0]: input json
-			// [1]: expected deserialized response
+namespace GraphQL.Client.Serializer.Tests.TestData
+{
+    public class DeserializeResponseTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // object array structure:
+            // [0]: input json
+            // [1]: expected deserialized response
 
-			yield return new object[] {
-				"{\"errors\":[{\"message\":\"Throttled\",\"extensions\":{\"code\":\"THROTTLED\",\"documentation\":\"https://help.shopify.com/api/graphql-admin-api/graphql-admin-api-rate-limits\"}}],\"extensions\":{\"cost\":{\"requestedQueryCost\":992,\"actualQueryCost\":null,\"throttleStatus\":{\"maximumAvailable\":1000,\"currentlyAvailable\":632,\"restoreRate\":50}}}}",
-				new GraphQLResponse<object> {
-					Data = null,
-					Errors = new[] {
-						new GraphQLError {
-							Message = "Throttled",
-							Extensions = new GraphQLExtensionsType {
-								{"code", "THROTTLED" },
-								{"documentation", "https://help.shopify.com/api/graphql-admin-api/graphql-admin-api-rate-limits" }
-							}
-						}
-					},
-					Extensions = new GraphQLExtensionsType {
-						{"cost", new Dictionary<string, object> {
-							{"requestedQueryCost", 992},
-							{"actualQueryCost", null},
-							{"throttleStatus", new Dictionary<string, object> {
-								{"maximumAvailable", 1000},
-								{"currentlyAvailable", 632},
-								{"restoreRate", 50}
-							}}
-						}}
-					}
-				}
-			};
-		}
+            yield return new object[] {
+                "{\"errors\":[{\"message\":\"Throttled\",\"extensions\":{\"code\":\"THROTTLED\",\"documentation\":\"https://help.shopify.com/api/graphql-admin-api/graphql-admin-api-rate-limits\"}}],\"extensions\":{\"cost\":{\"requestedQueryCost\":992,\"actualQueryCost\":null,\"throttleStatus\":{\"maximumAvailable\":1000,\"currentlyAvailable\":632,\"restoreRate\":50}}}}",
+                new GraphQLResponse<object> {
+                    Data = null,
+                    Errors = new[] {
+                        new GraphQLError {
+                            Message = "Throttled",
+                            Extensions = new GraphQLExtensionsType {
+                                {"code", "THROTTLED" },
+                                {"documentation", "https://help.shopify.com/api/graphql-admin-api/graphql-admin-api-rate-limits" }
+                            }
+                        }
+                    },
+                    Extensions = new GraphQLExtensionsType {
+                        {"cost", new Dictionary<string, object> {
+                            {"requestedQueryCost", 992},
+                            {"actualQueryCost", null},
+                            {"throttleStatus", new Dictionary<string, object> {
+                                {"maximumAvailable", 1000},
+                                {"currentlyAvailable", 632},
+                                {"restoreRate", 50}
+                            }}
+                        }}
+                    }
+                }
+            };
+        }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
-	}
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToBytesTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToBytesTestData.cs
@@ -3,30 +3,34 @@ using System.Collections.Generic;
 using GraphQL.Client.Abstractions.Websocket;
 using GraphQL.Client.Tests.Common.Chat;
 
-namespace GraphQL.Client.Serializer.Tests.TestData {
-	public class SerializeToBytesTestData : IEnumerable<object[]> {
-		public IEnumerator<object[]> GetEnumerator() {
-			yield return new object[] {
-				"{\"id\":\"1234567\",\"type\":\"start\",\"payload\":{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null}}",
-				new GraphQLWebSocketRequest {
-					Id = "1234567",
-					Type = GraphQLWebSocketMessageType.GQL_START,
-					Payload = new GraphQLRequest("simplequerystring")
-				}
-			};
-			yield return new object[] {
-				"{\"id\":\"34476567\",\"type\":\"start\",\"payload\":{\"query\":\"simplequerystring\",\"variables\":{\"camelCaseProperty\":\"camelCase\",\"PascalCaseProperty\":\"PascalCase\"},\"operationName\":null}}",
-				new GraphQLWebSocketRequest {
-					Id = "34476567",
-					Type = GraphQLWebSocketMessageType.GQL_START,
-					Payload = new GraphQLRequest("simple query string", new { camelCaseProperty = "camelCase", PascalCaseProperty = "PascalCase"})
-				}
-				
-			};
-		}
+namespace GraphQL.Client.Serializer.Tests.TestData
+{
+    public class SerializeToBytesTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {
+                "{\"id\":\"1234567\",\"type\":\"start\",\"payload\":{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null}}",
+                new GraphQLWebSocketRequest {
+                    Id = "1234567",
+                    Type = GraphQLWebSocketMessageType.GQL_START,
+                    Payload = new GraphQLRequest("simplequerystring")
+                }
+            };
+            yield return new object[] {
+                "{\"id\":\"34476567\",\"type\":\"start\",\"payload\":{\"query\":\"simplequerystring\",\"variables\":{\"camelCaseProperty\":\"camelCase\",\"PascalCaseProperty\":\"PascalCase\"},\"operationName\":null}}",
+                new GraphQLWebSocketRequest {
+                    Id = "34476567",
+                    Type = GraphQLWebSocketMessageType.GQL_START,
+                    Payload = new GraphQLRequest("simple query string", new { camelCaseProperty = "camelCase", PascalCaseProperty = "PascalCase"})
+                }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
-	}
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToBytesTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToBytesTestData.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using GraphQL.Client.Abstractions.Websocket;
-using GraphQL.Client.Tests.Common.Chat;
 
 namespace GraphQL.Client.Serializer.Tests.TestData
 {
@@ -28,9 +27,6 @@ namespace GraphQL.Client.Serializer.Tests.TestData
             };
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToStringTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToStringTestData.cs
@@ -2,25 +2,29 @@ using System.Collections;
 using System.Collections.Generic;
 using GraphQL.Client.Tests.Common.Chat;
 
-namespace GraphQL.Client.Serializer.Tests.TestData {
-	public class SerializeToStringTestData : IEnumerable<object[]> {
-		public IEnumerator<object[]> GetEnumerator() {
-			yield return new object[] {
-				"{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null}",
-				new GraphQLRequest("simple query string")
-			};
-			yield return new object[] {
-				"{\"query\":\"simplequerystring\",\"variables\":{\"camelCaseProperty\":\"camelCase\",\"PascalCaseProperty\":\"PascalCase\"},\"operationName\":null}",
-				new GraphQLRequest("simple query string", new { camelCaseProperty = "camelCase", PascalCaseProperty = "PascalCase"})
-			};
-			yield return new object[] {
-				"{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null,\"authentication\":\"an-authentication-token\"}",
-				new GraphQLRequest("simple query string"){{"authentication", "an-authentication-token"}}
-			};
-		}
+namespace GraphQL.Client.Serializer.Tests.TestData
+{
+    public class SerializeToStringTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {
+                "{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null}",
+                new GraphQLRequest("simple query string")
+            };
+            yield return new object[] {
+                "{\"query\":\"simplequerystring\",\"variables\":{\"camelCaseProperty\":\"camelCase\",\"PascalCaseProperty\":\"PascalCase\"},\"operationName\":null}",
+                new GraphQLRequest("simple query string", new { camelCaseProperty = "camelCase", PascalCaseProperty = "PascalCase"})
+            };
+            yield return new object[] {
+                "{\"query\":\"simplequerystring\",\"variables\":null,\"operationName\":null,\"authentication\":\"an-authentication-token\"}",
+                new GraphQLRequest("simple query string"){{"authentication", "an-authentication-token"}}
+            };
+        }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToStringTestData.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/TestData/SerializeToStringTestData.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using GraphQL.Client.Tests.Common.Chat;
 
 namespace GraphQL.Client.Serializer.Tests.TestData
 {
@@ -22,9 +21,6 @@ namespace GraphQL.Client.Serializer.Tests.TestData
             };
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/AddMessageMutationResult.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/AddMessageMutationResult.cs
@@ -1,9 +1,11 @@
 namespace GraphQL.Client.Tests.Common.Chat
 {
-	public class AddMessageMutationResult {
-		public AddMessageContent AddMessage { get; set; }
-		public class AddMessageContent {
-			public string Content { get; set; }
-		}
-	}
+    public class AddMessageMutationResult
+    {
+        public AddMessageContent AddMessage { get; set; }
+        public class AddMessageContent
+        {
+            public string Content { get; set; }
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/AddMessageVariables.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/AddMessageVariables.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GraphQL.Client.Tests.Common.Chat
 {

--- a/tests/GraphQL.Client.Tests.Common/Chat/AddMessageVariables.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/AddMessageVariables.cs
@@ -2,14 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace GraphQL.Client.Tests.Common.Chat {
-	public class AddMessageVariables {
+namespace GraphQL.Client.Tests.Common.Chat
+{
+    public class AddMessageVariables
+    {
 
-		public AddMessageInput Input { get; set; }
-		public class AddMessageInput {
-			public string FromId { get; set; }
-			public string Content { get; set; }
-			public DateTime SentAt { get; set; }
-		}
-	}
+        public AddMessageInput Input { get; set; }
+        public class AddMessageInput
+        {
+            public string FromId { get; set; }
+            public string Content { get; set; }
+            public DateTime SentAt { get; set; }
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/GraphQLClientChatExtensions.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/GraphQLClientChatExtensions.cs
@@ -2,41 +2,48 @@ using System;
 using System.Threading.Tasks;
 using GraphQL.Client.Abstractions;
 
-namespace GraphQL.Client.Tests.Common.Chat {
-	public static class GraphQLClientChatExtensions {
-		public const string AddMessageQuery =
+namespace GraphQL.Client.Tests.Common.Chat
+{
+    public static class GraphQLClientChatExtensions
+    {
+        public const string AddMessageQuery =
 @"mutation($input: MessageInputType){
   addMessage(message: $input){
     content
   }  
 }";
 
-		public static Task<GraphQLResponse<AddMessageMutationResult>> AddMessageAsync(this IGraphQLClient client, string message) {
-			var variables = new AddMessageVariables {
-				Input = new AddMessageVariables.AddMessageInput {
-					FromId = "2",
-					Content = message,
-					SentAt = DateTime.Now
-				}
-			};
+        public static Task<GraphQLResponse<AddMessageMutationResult>> AddMessageAsync(this IGraphQLClient client, string message)
+        {
+            var variables = new AddMessageVariables
+            {
+                Input = new AddMessageVariables.AddMessageInput
+                {
+                    FromId = "2",
+                    Content = message,
+                    SentAt = DateTime.Now
+                }
+            };
 
-			var graphQLRequest = new GraphQLRequest(AddMessageQuery, variables);
-			return client.SendMutationAsync<AddMessageMutationResult>(graphQLRequest);
-		}
+            var graphQLRequest = new GraphQLRequest(AddMessageQuery, variables);
+            return client.SendMutationAsync<AddMessageMutationResult>(graphQLRequest);
+        }
 
-		public static Task<GraphQLResponse<JoinDeveloperMutationResult>> JoinDeveloperUser(this IGraphQLClient client) {
-			var graphQLRequest = new GraphQLRequest(@"
+        public static Task<GraphQLResponse<JoinDeveloperMutationResult>> JoinDeveloperUser(this IGraphQLClient client)
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				mutation($userId: String){
 				  join(userId: $userId){
 				    displayName
 				    id
 				  }
 				}",
-				new {
-					userId = "1"
-				});
-			return client.SendMutationAsync<JoinDeveloperMutationResult>(graphQLRequest);
-		}
+                new
+                {
+                    userId = "1"
+                });
+            return client.SendMutationAsync<JoinDeveloperMutationResult>(graphQLRequest);
+        }
 
-	}
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/GraphQLClientChatExtensions.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/GraphQLClientChatExtensions.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Client.Tests.Common.Chat
 {
     public static class GraphQLClientChatExtensions
     {
-        public const string AddMessageQuery =
+        public const string ADD_MESSAGE_QUERY =
 @"mutation($input: MessageInputType){
   addMessage(message: $input){
     content
@@ -25,7 +25,7 @@ namespace GraphQL.Client.Tests.Common.Chat
                 }
             };
 
-            var graphQLRequest = new GraphQLRequest(AddMessageQuery, variables);
+            var graphQLRequest = new GraphQLRequest(ADD_MESSAGE_QUERY, variables);
             return client.SendMutationAsync<AddMessageMutationResult>(graphQLRequest);
         }
 

--- a/tests/GraphQL.Client.Tests.Common/Chat/JoinDeveloperMutationResult.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/JoinDeveloperMutationResult.cs
@@ -1,10 +1,12 @@
 namespace GraphQL.Client.Tests.Common.Chat
 {
-	public class JoinDeveloperMutationResult {
-		public JoinContent Join { get; set; }
-		public class JoinContent {
-			public string DisplayName { get; set; }
-			public string Id { get; set; }
-		}
-	}
+    public class JoinDeveloperMutationResult
+    {
+        public JoinContent Join { get; set; }
+        public class JoinContent
+        {
+            public string DisplayName { get; set; }
+            public string Id { get; set; }
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/CapitalizedFieldsGraphType.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/CapitalizedFieldsGraphType.cs
@@ -1,13 +1,16 @@
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class CapitalizedFieldsGraphType: ObjectGraphType {
-		public CapitalizedFieldsGraphType() {
-			Name = "CapitalizedFields";
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class CapitalizedFieldsGraphType : ObjectGraphType
+    {
+        public CapitalizedFieldsGraphType()
+        {
+            Name = "CapitalizedFields";
 
-			Field<StringGraphType>()
-				.Name("StringField")
-				.Resolve(context => "hello world");
-		}
-	}
+            Field<StringGraphType>()
+                .Name("StringField")
+                .Resolve(context => "hello world");
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatMutation.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatMutation.cs
@@ -1,35 +1,42 @@
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class ChatMutation : ObjectGraphType<object> {
-		public ChatMutation(IChat chat) {
-			Field<MessageType>("addMessage",
-				arguments: new QueryArguments(
-					new QueryArgument<MessageInputType> { Name = "message" }
-				),
-				resolve: context => {
-					var receivedMessage = context.GetArgument<ReceivedMessage>("message");
-					var message = chat.AddMessage(receivedMessage);
-					return message;
-				});
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class ChatMutation : ObjectGraphType<object>
+    {
+        public ChatMutation(IChat chat)
+        {
+            Field<MessageType>("addMessage",
+                arguments: new QueryArguments(
+                    new QueryArgument<MessageInputType> { Name = "message" }
+                ),
+                resolve: context =>
+                {
+                    var receivedMessage = context.GetArgument<ReceivedMessage>("message");
+                    var message = chat.AddMessage(receivedMessage);
+                    return message;
+                });
 
-			Field<MessageFromType>("join",
-				arguments: new QueryArguments(
-					new QueryArgument<StringGraphType> { Name = "userId" }
-				),
-				resolve: context => {
-					var userId = context.GetArgument<string>("userId");
-					var userJoined = chat.Join(userId);
-					return userJoined;
-				});
-		}
-	}
+            Field<MessageFromType>("join",
+                arguments: new QueryArguments(
+                    new QueryArgument<StringGraphType> { Name = "userId" }
+                ),
+                resolve: context =>
+                {
+                    var userId = context.GetArgument<string>("userId");
+                    var userJoined = chat.Join(userId);
+                    return userJoined;
+                });
+        }
+    }
 
-	public class MessageInputType : InputObjectGraphType {
-		public MessageInputType() {
-			Field<StringGraphType>("fromId");
-			Field<StringGraphType>("content");
-			Field<DateGraphType>("sentAt");
-		}
-	}
+    public class MessageInputType : InputObjectGraphType
+    {
+        public MessageInputType()
+        {
+            Field<StringGraphType>("fromId");
+            Field<StringGraphType>("content");
+            Field<DateGraphType>("sentAt");
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatQuery.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatQuery.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatQuery.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatQuery.cs
@@ -4,40 +4,45 @@ using System.Linq;
 using System.Threading;
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class ChatQuery : ObjectGraphType {
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class ChatQuery : ObjectGraphType
+    {
 
-		public static readonly Dictionary<string, object> TestExtensions = new Dictionary<string, object> {
-			{"extension1", "hello world"},
-			{"another extension", 4711}
-		};
+        public static readonly Dictionary<string, object> TestExtensions = new Dictionary<string, object> {
+            {"extension1", "hello world"},
+            {"another extension", 4711}
+        };
 
-		// properties for unit testing
+        // properties for unit testing
 
-		public readonly ManualResetEventSlim LongRunningQueryBlocker = new ManualResetEventSlim();
-		public readonly ManualResetEventSlim WaitingOnQueryBlocker = new ManualResetEventSlim();
+        public readonly ManualResetEventSlim LongRunningQueryBlocker = new ManualResetEventSlim();
+        public readonly ManualResetEventSlim WaitingOnQueryBlocker = new ManualResetEventSlim();
 
 
-		public ChatQuery(IChat chat) {
-			Name = "ChatQuery";
+        public ChatQuery(IChat chat)
+        {
+            Name = "ChatQuery";
 
-			Field<ListGraphType<MessageType>>("messages", resolve: context => chat.AllMessages.Take(100));
+            Field<ListGraphType<MessageType>>("messages", resolve: context => chat.AllMessages.Take(100));
 
-			Field<StringGraphType>()
-				.Name("extensionsTest")
-				.Resolve(context => {
-					context.Errors.Add(new ExecutionError("this error contains extension fields", TestExtensions));
-					return null;
-				});
+            Field<StringGraphType>()
+                .Name("extensionsTest")
+                .Resolve(context =>
+                {
+                    context.Errors.Add(new ExecutionError("this error contains extension fields", TestExtensions));
+                    return null;
+                });
 
-			Field<StringGraphType>()
-				.Name("longRunning")
-				.Resolve(context => {
-					WaitingOnQueryBlocker.Set();
-					LongRunningQueryBlocker.Wait();
-					WaitingOnQueryBlocker.Reset();
-					return "finally returned";
-				});
-		}
-	}
+            Field<StringGraphType>()
+                .Name("longRunning")
+                .Resolve(context =>
+                {
+                    WaitingOnQueryBlocker.Set();
+                    LongRunningQueryBlocker.Wait();
+                    WaitingOnQueryBlocker.Reset();
+                    return "finally returned";
+                });
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatSchema.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatSchema.cs
@@ -1,10 +1,13 @@
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class ChatSchema : Types.Schema {
-		public ChatSchema(IDependencyResolver resolver)
-			: base(resolver) {
-			Query = resolver.Resolve<ChatQuery>();
-			Mutation = resolver.Resolve<ChatMutation>();
-			Subscription = resolver.Resolve<ChatSubscriptions>();
-		}
-	}
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class ChatSchema : Types.Schema
+    {
+        public ChatSchema(IDependencyResolver resolver)
+            : base(resolver)
+        {
+            Query = resolver.Resolve<ChatQuery>();
+            Mutation = resolver.Resolve<ChatMutation>();
+            Subscription = resolver.Resolve<ChatSubscriptions>();
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatSubscriptions.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ChatSubscriptions.cs
@@ -7,81 +7,92 @@ using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Subscription;
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class ChatSubscriptions : ObjectGraphType<object> {
-		private readonly IChat _chat;
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class ChatSubscriptions : ObjectGraphType<object>
+    {
+        private readonly IChat _chat;
 
-		public ChatSubscriptions(IChat chat) {
-			_chat = chat;
-			AddField(new EventStreamFieldType {
-				Name = "messageAdded",
-				Type = typeof(MessageType),
-				Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-				Subscriber = new EventStreamResolver<Message>(Subscribe)
-			});
+        public ChatSubscriptions(IChat chat)
+        {
+            _chat = chat;
+            AddField(new EventStreamFieldType
+            {
+                Name = "messageAdded",
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(Subscribe)
+            });
 
-			AddField(new EventStreamFieldType {
-				Name = "contentAdded",
-				Type = typeof(MessageType),
-				Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-				Subscriber = new EventStreamResolver<Message>(Subscribe)
-			});
+            AddField(new EventStreamFieldType
+            {
+                Name = "contentAdded",
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(Subscribe)
+            });
 
-			AddField(new EventStreamFieldType {
-				Name = "messageAddedByUser",
-				Arguments = new QueryArguments(
-					new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
-				),
-				Type = typeof(MessageType),
-				Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-				Subscriber = new EventStreamResolver<Message>(SubscribeById)
-			});
+            AddField(new EventStreamFieldType
+            {
+                Name = "messageAddedByUser",
+                Arguments = new QueryArguments(
+                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
+                ),
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(SubscribeById)
+            });
 
-			AddField(new EventStreamFieldType {
-				Name = "userJoined",
-				Type = typeof(MessageFromType),
-				Resolver = new FuncFieldResolver<MessageFrom>(context => context.Source as MessageFrom),
-				Subscriber = new EventStreamResolver<MessageFrom>(context => _chat.UserJoined())
-			});
+            AddField(new EventStreamFieldType
+            {
+                Name = "userJoined",
+                Type = typeof(MessageFromType),
+                Resolver = new FuncFieldResolver<MessageFrom>(context => context.Source as MessageFrom),
+                Subscriber = new EventStreamResolver<MessageFrom>(context => _chat.UserJoined())
+            });
 
 
-			AddField(new EventStreamFieldType {
-				Name = "failImmediately",
-				Type = typeof(MessageType),
-				Resolver = new FuncFieldResolver<Message>(ResolveMessage),
-				Subscriber = new EventStreamResolver<Message>(context => throw new NotSupportedException("this is supposed to fail"))
-			});
-		}
+            AddField(new EventStreamFieldType
+            {
+                Name = "failImmediately",
+                Type = typeof(MessageType),
+                Resolver = new FuncFieldResolver<Message>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Message>(context => throw new NotSupportedException("this is supposed to fail"))
+            });
+        }
 
-		private IObservable<Message> SubscribeById(ResolveEventStreamContext context) {
-			var messageContext = context.UserContext.As<MessageHandlingContext>();
-			var user = messageContext.Get<ClaimsPrincipal>("user");
+        private IObservable<Message> SubscribeById(ResolveEventStreamContext context)
+        {
+            var messageContext = context.UserContext.As<MessageHandlingContext>();
+            var user = messageContext.Get<ClaimsPrincipal>("user");
 
-			var sub = "Anonymous";
-			if (user != null)
-				sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+            var sub = "Anonymous";
+            if (user != null)
+                sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
 
-			var messages = _chat.Messages(sub);
+            var messages = _chat.Messages(sub);
 
-			var id = context.GetArgument<string>("id");
-			return messages.Where(message => message.From.Id == id);
-		}
+            var id = context.GetArgument<string>("id");
+            return messages.Where(message => message.From.Id == id);
+        }
 
-		private Message ResolveMessage(ResolveFieldContext context) {
-			var message = context.Source as Message;
+        private Message ResolveMessage(ResolveFieldContext context)
+        {
+            var message = context.Source as Message;
 
-			return message;
-		}
+            return message;
+        }
 
-		private IObservable<Message> Subscribe(ResolveEventStreamContext context) {
-			var messageContext = context.UserContext.As<MessageHandlingContext>();
-			var user = messageContext.Get<ClaimsPrincipal>("user");
+        private IObservable<Message> Subscribe(ResolveEventStreamContext context)
+        {
+            var messageContext = context.UserContext.As<MessageHandlingContext>();
+            var user = messageContext.Get<ClaimsPrincipal>("user");
 
-			var sub = "Anonymous";
-			if (user != null)
-				sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+            var sub = "Anonymous";
+            if (user != null)
+                sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
 
-			return _chat.Messages(sub);
-		}
-	}
+            return _chat.Messages(sub);
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/IChat.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/IChat.cs
@@ -21,8 +21,8 @@ namespace GraphQL.Client.Tests.Common.Chat.Schema
 
     public class Chat : IChat
     {
-        private readonly ISubject<Message> messageStream = new ReplaySubject<Message>(1);
-        private readonly ISubject<MessageFrom> userJoined = new Subject<MessageFrom>();
+        private readonly ISubject<Message> _messageStream = new ReplaySubject<Message>(1);
+        private readonly ISubject<MessageFrom> _userJoined = new Subject<MessageFrom>();
 
         public Chat()
         {
@@ -60,7 +60,7 @@ namespace GraphQL.Client.Tests.Common.Chat.Schema
         public Message AddMessage(Message message)
         {
             AllMessages.Push(message);
-            messageStream.OnNext(message);
+            _messageStream.OnNext(message);
             return message;
         }
 
@@ -77,30 +77,22 @@ namespace GraphQL.Client.Tests.Common.Chat.Schema
                 DisplayName = displayName
             };
 
-            userJoined.OnNext(joinedUser);
+            _userJoined.OnNext(joinedUser);
             return joinedUser;
         }
 
-        public IObservable<Message> Messages(string user)
-        {
-            return messageStream
+        public IObservable<Message> Messages(string user) =>
+            _messageStream
                 .Select(message =>
                 {
                     message.Sub = user;
                     return message;
                 })
                 .AsObservable();
-        }
 
-        public void AddError(Exception exception)
-        {
-            messageStream.OnError(exception);
-        }
+        public void AddError(Exception exception) => _messageStream.OnError(exception);
 
-        public IObservable<MessageFrom> UserJoined()
-        {
-            return userJoined.AsObservable();
-        }
+        public IObservable<MessageFrom> UserJoined() => _userJoined.AsObservable();
     }
 
     public class User

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/IChat.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/IChat.cs
@@ -3,91 +3,109 @@ using System.Collections.Concurrent;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public interface IChat {
-		ConcurrentStack<Message> AllMessages { get; }
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public interface IChat
+    {
+        ConcurrentStack<Message> AllMessages { get; }
 
-		Message AddMessage(Message message);
+        Message AddMessage(Message message);
 
-		MessageFrom Join(string userId);
+        MessageFrom Join(string userId);
 
-		IObservable<Message> Messages(string user);
-		IObservable<MessageFrom> UserJoined();
+        IObservable<Message> Messages(string user);
+        IObservable<MessageFrom> UserJoined();
 
-		Message AddMessage(ReceivedMessage message);
-	}
-	
-	public class Chat : IChat {
-		private readonly ISubject<Message> messageStream = new ReplaySubject<Message>(1);
-		private readonly ISubject<MessageFrom> userJoined = new Subject<MessageFrom>();
+        Message AddMessage(ReceivedMessage message);
+    }
 
-		public Chat() {
-			AllMessages = new ConcurrentStack<Message>();
-			Users = new ConcurrentDictionary<string, string> {
-				["1"] = "developer",
-				["2"] = "tester"
-			};
-		}
+    public class Chat : IChat
+    {
+        private readonly ISubject<Message> messageStream = new ReplaySubject<Message>(1);
+        private readonly ISubject<MessageFrom> userJoined = new Subject<MessageFrom>();
 
-		public ConcurrentDictionary<string, string> Users { get; private set; }
+        public Chat()
+        {
+            AllMessages = new ConcurrentStack<Message>();
+            Users = new ConcurrentDictionary<string, string>
+            {
+                ["1"] = "developer",
+                ["2"] = "tester"
+            };
+        }
 
-		public ConcurrentStack<Message> AllMessages { get; private set; }
+        public ConcurrentDictionary<string, string> Users { get; private set; }
 
-		public Message AddMessage(ReceivedMessage message) {
-			if (!Users.TryGetValue(message.FromId, out var displayName)) {
-				displayName = "(unknown)";
-			}
+        public ConcurrentStack<Message> AllMessages { get; private set; }
 
-			return AddMessage(new Message {
-				Content = message.Content,
-				SentAt = message.SentAt,
-				From = new MessageFrom {
-					DisplayName = displayName,
-					Id = message.FromId
-				}
-			});
-		}
+        public Message AddMessage(ReceivedMessage message)
+        {
+            if (!Users.TryGetValue(message.FromId, out var displayName))
+            {
+                displayName = "(unknown)";
+            }
 
-		public Message AddMessage(Message message) {
-			AllMessages.Push(message);
-			messageStream.OnNext(message);
-			return message;
-		}
+            return AddMessage(new Message
+            {
+                Content = message.Content,
+                SentAt = message.SentAt,
+                From = new MessageFrom
+                {
+                    DisplayName = displayName,
+                    Id = message.FromId
+                }
+            });
+        }
 
-		public MessageFrom Join(string userId) {
-			if (!Users.TryGetValue(userId, out var displayName)) {
-				displayName = "(unknown)";
-			}
+        public Message AddMessage(Message message)
+        {
+            AllMessages.Push(message);
+            messageStream.OnNext(message);
+            return message;
+        }
 
-			var joinedUser = new MessageFrom {
-				Id = userId,
-				DisplayName = displayName
-			};
+        public MessageFrom Join(string userId)
+        {
+            if (!Users.TryGetValue(userId, out var displayName))
+            {
+                displayName = "(unknown)";
+            }
 
-			userJoined.OnNext(joinedUser);
-			return joinedUser;
-		}
+            var joinedUser = new MessageFrom
+            {
+                Id = userId,
+                DisplayName = displayName
+            };
 
-		public IObservable<Message> Messages(string user) {
-			return messageStream
-				.Select(message => {
-					message.Sub = user;
-					return message;
-				})
-				.AsObservable();
-		}
+            userJoined.OnNext(joinedUser);
+            return joinedUser;
+        }
 
-		public void AddError(Exception exception) {
-			messageStream.OnError(exception);
-		}
+        public IObservable<Message> Messages(string user)
+        {
+            return messageStream
+                .Select(message =>
+                {
+                    message.Sub = user;
+                    return message;
+                })
+                .AsObservable();
+        }
 
-		public IObservable<MessageFrom> UserJoined() {
-			return userJoined.AsObservable();
-		}
-	}
+        public void AddError(Exception exception)
+        {
+            messageStream.OnError(exception);
+        }
 
-	public class User {
-		public string Id { get; set; }
-		public string Name { get; set; }
-	}
+        public IObservable<MessageFrom> UserJoined()
+        {
+            return userJoined.AsObservable();
+        }
+    }
+
+    public class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/Message.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/Message.cs
@@ -1,13 +1,15 @@
 using System;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class Message {
-		public MessageFrom From { get; set; }
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class Message
+    {
+        public MessageFrom From { get; set; }
 
-		public string Sub { get; set; }
+        public string Sub { get; set; }
 
-		public string Content { get; set; }
+        public string Content { get; set; }
 
-		public DateTime SentAt { get; set; }
-	}
+        public DateTime SentAt { get; set; }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageFrom.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageFrom.cs
@@ -1,7 +1,9 @@
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class MessageFrom {
-		public string Id { get; set; }
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class MessageFrom
+    {
+        public string Id { get; set; }
 
-		public string DisplayName { get; set; }
-	}
+        public string DisplayName { get; set; }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageFromType.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageFromType.cs
@@ -1,10 +1,13 @@
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class MessageFromType : ObjectGraphType<MessageFrom> {
-		public MessageFromType() {
-			Field(o => o.Id);
-			Field(o => o.DisplayName);
-		}
-	}
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class MessageFromType : ObjectGraphType<MessageFrom>
+    {
+        public MessageFromType()
+        {
+            Field(o => o.Id);
+            Field(o => o.DisplayName);
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageType.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/MessageType.cs
@@ -1,17 +1,21 @@
 using GraphQL.Types;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class MessageType : ObjectGraphType<Message> {
-		public MessageType() {
-			Field(o => o.Content);
-			Field(o => o.SentAt);
-			Field(o => o.Sub);
-			Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
-		}
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class MessageType : ObjectGraphType<Message>
+    {
+        public MessageType()
+        {
+            Field(o => o.Content);
+            Field(o => o.SentAt);
+            Field(o => o.Sub);
+            Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
+        }
 
-		private MessageFrom ResolveFrom(ResolveFieldContext<Message> context) {
-			var message = context.Source;
-			return message.From;
-		}
-	}
+        private MessageFrom ResolveFrom(ResolveFieldContext<Message> context)
+        {
+            var message = context.Source;
+            return message.From;
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Chat/Schema/ReceivedMessage.cs
+++ b/tests/GraphQL.Client.Tests.Common/Chat/Schema/ReceivedMessage.cs
@@ -1,11 +1,13 @@
 using System;
 
-namespace GraphQL.Client.Tests.Common.Chat.Schema {
-	public class ReceivedMessage {
-		public string FromId { get; set; }
+namespace GraphQL.Client.Tests.Common.Chat.Schema
+{
+    public class ReceivedMessage
+    {
+        public string FromId { get; set; }
 
-		public string Content { get; set; }
+        public string Content { get; set; }
 
-		public DateTime SentAt { get; set; }
-	}
+        public DateTime SentAt { get; set; }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Common.cs
+++ b/tests/GraphQL.Client.Tests.Common/Common.cs
@@ -5,46 +5,51 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Client.Tests.Common
 {
-    public static class Common {
-	    public const string StarWarsEndpoint = "/graphql/starwars";
-	    public const string ChatEndpoint = "/graphql/chat";
+    public static class Common
+    {
+        public const string StarWarsEndpoint = "/graphql/starwars";
+        public const string ChatEndpoint = "/graphql/chat";
 
-		public static StarWarsSchema GetStarWarsSchema() {
-			var services = new ServiceCollection();
-			services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
-			services.AddStarWarsSchema();
-			return services.BuildServiceProvider().GetRequiredService<StarWarsSchema>();
-		}
-		public static ChatSchema GetChatSchema() {
-			var services = new ServiceCollection();
-			services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
-			services.AddChatSchema();
-			return services.BuildServiceProvider().GetRequiredService<ChatSchema>();
-		}
+        public static StarWarsSchema GetStarWarsSchema()
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
+            services.AddStarWarsSchema();
+            return services.BuildServiceProvider().GetRequiredService<StarWarsSchema>();
+        }
+        public static ChatSchema GetChatSchema()
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
+            services.AddChatSchema();
+            return services.BuildServiceProvider().GetRequiredService<ChatSchema>();
+        }
 
-		public static void AddStarWarsSchema(this IServiceCollection services) {
-		    services.AddSingleton<StarWarsData>();
-		    services.AddSingleton<StarWarsQuery>();
-		    services.AddSingleton<StarWarsMutation>();
-		    services.AddSingleton<StarWarsSchema>();
-		    services.AddTransient<CharacterInterface>();
-		    services.AddTransient<DroidType>();
-		    services.AddTransient<EpisodeEnum>();
-		    services.AddTransient<HumanType>();
-		    services.AddTransient<HumanInputType>();
-		}
-		
-	    public static void AddChatSchema(this IServiceCollection services) {
-		    var chat = new Chat.Schema.Chat();
-		    services.AddSingleton(chat);
-		    services.AddSingleton<IChat>(chat);
-			services.AddSingleton<ChatSchema>();
-		    services.AddSingleton<ChatQuery>();
-		    services.AddSingleton<ChatMutation>();
-		    services.AddSingleton<ChatSubscriptions>();
-		    services.AddSingleton<MessageType>();
-		    services.AddSingleton<MessageInputType>();
-		    services.AddSingleton<MessageFromType>();
-		}
+        public static void AddStarWarsSchema(this IServiceCollection services)
+        {
+            services.AddSingleton<StarWarsData>();
+            services.AddSingleton<StarWarsQuery>();
+            services.AddSingleton<StarWarsMutation>();
+            services.AddSingleton<StarWarsSchema>();
+            services.AddTransient<CharacterInterface>();
+            services.AddTransient<DroidType>();
+            services.AddTransient<EpisodeEnum>();
+            services.AddTransient<HumanType>();
+            services.AddTransient<HumanInputType>();
+        }
+
+        public static void AddChatSchema(this IServiceCollection services)
+        {
+            var chat = new Chat.Schema.Chat();
+            services.AddSingleton(chat);
+            services.AddSingleton<IChat>(chat);
+            services.AddSingleton<ChatSchema>();
+            services.AddSingleton<ChatQuery>();
+            services.AddSingleton<ChatMutation>();
+            services.AddSingleton<ChatSubscriptions>();
+            services.AddSingleton<MessageType>();
+            services.AddSingleton<MessageInputType>();
+            services.AddSingleton<MessageFromType>();
+        }
     }
 }

--- a/tests/GraphQL.Client.Tests.Common/Common.cs
+++ b/tests/GraphQL.Client.Tests.Common/Common.cs
@@ -7,8 +7,8 @@ namespace GraphQL.Client.Tests.Common
 {
     public static class Common
     {
-        public const string StarWarsEndpoint = "/graphql/starwars";
-        public const string ChatEndpoint = "/graphql/chat";
+        public const string STAR_WARS_ENDPOINT = "/graphql/starwars";
+        public const string CHAT_ENDPOINT = "/graphql/chat";
 
         public static StarWarsSchema GetStarWarsSchema()
         {

--- a/tests/GraphQL.Client.Tests.Common/Helpers/AvailableJsonSerializers.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/AvailableJsonSerializers.cs
@@ -20,9 +20,6 @@ namespace GraphQL.Client.Tests.Common.Helpers
                 .GetEnumerator();
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/AvailableJsonSerializers.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/AvailableJsonSerializers.cs
@@ -4,21 +4,25 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Client.Abstractions;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
-	public class AvailableJsonSerializers<TSerializerInterface> : IEnumerable<object[]> where TSerializerInterface : IGraphQLJsonSerializer {
-		public IEnumerator<object[]> GetEnumerator() {
-				// try to find one in the assembly and assign that
-				var type = typeof(TSerializerInterface);
-				return AppDomain.CurrentDomain
-					.GetAssemblies()
-					.SelectMany(s => s.GetTypes())
-					.Where(p => type.IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract)
-					.Select(serializerType => new object[]{Activator.CreateInstance(serializerType)})
-					.GetEnumerator();
-		}
+namespace GraphQL.Client.Tests.Common.Helpers
+{
+    public class AvailableJsonSerializers<TSerializerInterface> : IEnumerable<object[]> where TSerializerInterface : IGraphQLJsonSerializer
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            // try to find one in the assembly and assign that
+            var type = typeof(TSerializerInterface);
+            return AppDomain.CurrentDomain
+                .GetAssemblies()
+                .SelectMany(s => s.GetTypes())
+                .Where(p => type.IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract)
+                .Select(serializerType => new object[] { Activator.CreateInstance(serializerType) })
+                .GetEnumerator();
+        }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/CallbackMonitor.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/CallbackMonitor.cs
@@ -5,84 +5,94 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
-	public class CallbackMonitor<T> {
-		private readonly ManualResetEventSlim callbackInvoked = new ManualResetEventSlim();
+namespace GraphQL.Client.Tests.Common.Helpers
+{
+    public class CallbackMonitor<T>
+    {
+        private readonly ManualResetEventSlim callbackInvoked = new ManualResetEventSlim();
 
-		/// <summary>
-		/// The timeout for <see cref="ShouldHaveReceivedUpdate"/>. Defaults to 1 s
-		/// </summary>
-		public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(1);
+        /// <summary>
+        /// The timeout for <see cref="ShouldHaveReceivedUpdate"/>. Defaults to 1 s
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(1);
 
-		/// <summary>
-		/// Indicates that an update has been received since the last <see cref="Reset"/>
-		/// </summary>
-		public bool CallbackInvoked => callbackInvoked.IsSet;
-		/// <summary>
-		/// The last payload which was received.
-		/// </summary>
-		public T LastPayload { get; private set; }
+        /// <summary>
+        /// Indicates that an update has been received since the last <see cref="Reset"/>
+        /// </summary>
+        public bool CallbackInvoked => callbackInvoked.IsSet;
+        /// <summary>
+        /// The last payload which was received.
+        /// </summary>
+        public T LastPayload { get; private set; }
 
-		public void Invoke(T param) {
-			LastPayload = param;
-			Debug.WriteLine($"CallbackMonitor invoke handler thread id: {Thread.CurrentThread.ManagedThreadId}");
-			callbackInvoked.Set();
-		}
-		
-		/// <summary>
-		/// Resets the tester class. Should be called before triggering the potential update
-		/// </summary>
-		public void Reset() {
-			LastPayload = default(T);
-			callbackInvoked.Reset();
-		}
-		
-		public CallbackAssertions<T> Should() {
-			return new CallbackAssertions<T>(this);
-		}
+        public void Invoke(T param)
+        {
+            LastPayload = param;
+            Debug.WriteLine($"CallbackMonitor invoke handler thread id: {Thread.CurrentThread.ManagedThreadId}");
+            callbackInvoked.Set();
+        }
 
-		public class CallbackAssertions<TPayload> : ReferenceTypeAssertions<CallbackMonitor<TPayload>, CallbackAssertions<TPayload>> {
-			public CallbackAssertions(CallbackMonitor<TPayload> tester) {
-				Subject = tester;
-			}
+        /// <summary>
+        /// Resets the tester class. Should be called before triggering the potential update
+        /// </summary>
+        public void Reset()
+        {
+            LastPayload = default(T);
+            callbackInvoked.Reset();
+        }
 
-			protected override string Identifier => "callback";
+        public CallbackAssertions<T> Should()
+        {
+            return new CallbackAssertions<T>(this);
+        }
 
-			public AndWhichConstraint<CallbackAssertions<TPayload>, TPayload> HaveBeenInvokedWithPayload(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => {
-						Debug.WriteLine($"HaveBeenInvokedWithPayload thread id: {Thread.CurrentThread.ManagedThreadId}");
-						return Subject.callbackInvoked.Wait(timeout);
-					})
-					.ForCondition(isSet => isSet)
-					.FailWith("Expected {context:callback} to be invoked{reason}, but did not receive a call within {0}", timeout);
+        public class CallbackAssertions<TPayload> : ReferenceTypeAssertions<CallbackMonitor<TPayload>, CallbackAssertions<TPayload>>
+        {
+            public CallbackAssertions(CallbackMonitor<TPayload> tester)
+            {
+                Subject = tester;
+            }
 
-				Subject.callbackInvoked.Reset();
-				return new AndWhichConstraint<CallbackAssertions<TPayload>, TPayload>(this, Subject.LastPayload);
-			}
-			public AndWhichConstraint<CallbackAssertions<TPayload>, TPayload> HaveBeenInvokedWithPayload(string because = "", params object[] becauseArgs)
-				=> HaveBeenInvokedWithPayload(Subject.Timeout, because, becauseArgs);
+            protected override string Identifier => "callback";
 
-			public AndConstraint<CallbackAssertions<TPayload>> HaveBeenInvoked(TimeSpan timeout, string because = "", params object[] becauseArgs)
-				=> HaveBeenInvokedWithPayload(timeout, because, becauseArgs);
-			public AndConstraint<CallbackAssertions<TPayload>> HaveBeenInvoked(string because = "", params object[] becauseArgs)
-				=> HaveBeenInvokedWithPayload(Subject.Timeout, because, becauseArgs);
+            public AndWhichConstraint<CallbackAssertions<TPayload>, TPayload> HaveBeenInvokedWithPayload(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() =>
+                    {
+                        Debug.WriteLine($"HaveBeenInvokedWithPayload thread id: {Thread.CurrentThread.ManagedThreadId}");
+                        return Subject.callbackInvoked.Wait(timeout);
+                    })
+                    .ForCondition(isSet => isSet)
+                    .FailWith("Expected {context:callback} to be invoked{reason}, but did not receive a call within {0}", timeout);
 
-			public AndConstraint<CallbackAssertions<TPayload>> NotHaveBeenInvoked(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => Subject.callbackInvoked.Wait(timeout))
-					.ForCondition(isSet => !isSet)
-					.FailWith("Expected {context:callback} to not be invoked{reason}, but did receive a call: {0}", Subject.LastPayload);
+                Subject.callbackInvoked.Reset();
+                return new AndWhichConstraint<CallbackAssertions<TPayload>, TPayload>(this, Subject.LastPayload);
+            }
+            public AndWhichConstraint<CallbackAssertions<TPayload>, TPayload> HaveBeenInvokedWithPayload(string because = "", params object[] becauseArgs)
+                => HaveBeenInvokedWithPayload(Subject.Timeout, because, becauseArgs);
 
-				Subject.callbackInvoked.Reset();
-				return new AndConstraint<CallbackAssertions<TPayload>>(this);
-			}
-			public AndConstraint<CallbackAssertions<TPayload>> NotHaveBeenInvoked(string because = "", params object[] becauseArgs)
-				=> NotHaveBeenInvoked(TimeSpan.FromMilliseconds(100), because, becauseArgs);
-		}
-	}
+            public AndConstraint<CallbackAssertions<TPayload>> HaveBeenInvoked(TimeSpan timeout, string because = "", params object[] becauseArgs)
+                => HaveBeenInvokedWithPayload(timeout, because, becauseArgs);
+            public AndConstraint<CallbackAssertions<TPayload>> HaveBeenInvoked(string because = "", params object[] becauseArgs)
+                => HaveBeenInvokedWithPayload(Subject.Timeout, because, becauseArgs);
+
+            public AndConstraint<CallbackAssertions<TPayload>> NotHaveBeenInvoked(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() => Subject.callbackInvoked.Wait(timeout))
+                    .ForCondition(isSet => !isSet)
+                    .FailWith("Expected {context:callback} to not be invoked{reason}, but did receive a call: {0}", Subject.LastPayload);
+
+                Subject.callbackInvoked.Reset();
+                return new AndConstraint<CallbackAssertions<TPayload>>(this);
+            }
+            public AndConstraint<CallbackAssertions<TPayload>> NotHaveBeenInvoked(string because = "", params object[] becauseArgs)
+                => NotHaveBeenInvoked(TimeSpan.FromMilliseconds(100), because, becauseArgs);
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/ConcurrentTaskWrapper.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/ConcurrentTaskWrapper.cs
@@ -6,60 +6,51 @@ namespace GraphQL.Client.Tests.Common.Helpers
 
     public class ConcurrentTaskWrapper
     {
-        public static ConcurrentTaskWrapper<TResult> New<TResult>(Func<Task<TResult>> createTask)
-        {
-            return new ConcurrentTaskWrapper<TResult>(createTask);
-        }
+        public static ConcurrentTaskWrapper<TResult> New<TResult>(Func<Task<TResult>> createTask) => new ConcurrentTaskWrapper<TResult>(createTask);
 
-        private readonly Func<Task> createTask;
-        private Task internalTask = null;
+        private readonly Func<Task> _createTask;
+        private Task _internalTask = null;
 
         public ConcurrentTaskWrapper(Func<Task> createTask)
         {
-            this.createTask = createTask;
+            _createTask = createTask;
         }
 
         public Task Invoke()
         {
-            if (internalTask != null)
-                return internalTask;
+            if (_internalTask != null)
+                return _internalTask;
 
-            return internalTask = createTask();
+            return _internalTask = _createTask();
         }
     }
 
     public class ConcurrentTaskWrapper<TResult>
     {
-        private readonly Func<Task<TResult>> createTask;
-        private Task<TResult> internalTask = null;
+        private readonly Func<Task<TResult>> _createTask;
+        private Task<TResult> _internalTask = null;
 
         public ConcurrentTaskWrapper(Func<Task<TResult>> createTask)
         {
-            this.createTask = createTask;
+            _createTask = createTask;
         }
 
         public Task<TResult> Invoke()
         {
-            if (internalTask != null)
-                return internalTask;
+            if (_internalTask != null)
+                return _internalTask;
 
-            return internalTask = createTask();
+            return _internalTask = _createTask();
         }
 
         public void Start()
         {
-            if (internalTask == null)
-                internalTask = createTask();
+            if (_internalTask == null)
+                _internalTask = _createTask();
         }
 
-        public Func<Task<TResult>> Invoking()
-        {
-            return Invoke;
-        }
+        public Func<Task<TResult>> Invoking() => Invoke;
 
-        public void Clear()
-        {
-            internalTask = null;
-        }
+        public void Clear() => _internalTask = null;
     }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/ConcurrentTaskWrapper.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/ConcurrentTaskWrapper.cs
@@ -1,54 +1,65 @@
 using System;
 using System.Threading.Tasks;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
+namespace GraphQL.Client.Tests.Common.Helpers
+{
 
-	public class ConcurrentTaskWrapper {
-		public static ConcurrentTaskWrapper<TResult> New<TResult>(Func<Task<TResult>> createTask) {
-			return  new ConcurrentTaskWrapper<TResult>(createTask);
-		}
+    public class ConcurrentTaskWrapper
+    {
+        public static ConcurrentTaskWrapper<TResult> New<TResult>(Func<Task<TResult>> createTask)
+        {
+            return new ConcurrentTaskWrapper<TResult>(createTask);
+        }
 
-		private readonly Func<Task> createTask;
-		private Task internalTask = null;
+        private readonly Func<Task> createTask;
+        private Task internalTask = null;
 
-		public ConcurrentTaskWrapper(Func<Task> createTask) {
-			this.createTask = createTask;
-		}
+        public ConcurrentTaskWrapper(Func<Task> createTask)
+        {
+            this.createTask = createTask;
+        }
 
-		public Task Invoke() {
-			if (internalTask != null)
-				return internalTask;
+        public Task Invoke()
+        {
+            if (internalTask != null)
+                return internalTask;
 
-			return internalTask = createTask();
-		}
-	}
+            return internalTask = createTask();
+        }
+    }
 
-	public class ConcurrentTaskWrapper<TResult> {
-		private readonly Func<Task<TResult>> createTask;
-		private Task<TResult> internalTask = null;
+    public class ConcurrentTaskWrapper<TResult>
+    {
+        private readonly Func<Task<TResult>> createTask;
+        private Task<TResult> internalTask = null;
 
-		public ConcurrentTaskWrapper(Func<Task<TResult>> createTask) {
-			this.createTask = createTask;
-		}
+        public ConcurrentTaskWrapper(Func<Task<TResult>> createTask)
+        {
+            this.createTask = createTask;
+        }
 
-		public Task<TResult> Invoke() {
-			if (internalTask != null)
-				return internalTask;
+        public Task<TResult> Invoke()
+        {
+            if (internalTask != null)
+                return internalTask;
 
-			return internalTask = createTask();
-		}
+            return internalTask = createTask();
+        }
 
-		public void Start() {
-			if (internalTask == null)
-				internalTask = createTask();
-		}
+        public void Start()
+        {
+            if (internalTask == null)
+                internalTask = createTask();
+        }
 
-		public Func<Task<TResult>> Invoking() {
-			return Invoke;
-		}
+        public Func<Task<TResult>> Invoking()
+        {
+            return Invoke;
+        }
 
-		public void Clear() {
-			internalTask = null;
-		}
-	}
+        public void Clear()
+        {
+            internalTask = null;
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/MiscellaneousExtensions.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/MiscellaneousExtensions.cs
@@ -6,12 +6,10 @@ namespace GraphQL.Client.Tests.Common.Helpers
 {
     public static class MiscellaneousExtensions
     {
-        public static string RemoveWhitespace(this string input)
-        {
-            return new string(input.ToCharArray()
+        public static string RemoveWhitespace(this string input) =>
+            new string(input.ToCharArray()
                 .Where(c => !char.IsWhiteSpace(c))
                 .ToArray());
-        }
 
         public static CallbackMonitor<GraphQLHttpClient> ConfigureMonitorForOnWebsocketConnected(
             this GraphQLHttpClient client)

--- a/tests/GraphQL.Client.Tests.Common/Helpers/MiscellaneousExtensions.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/MiscellaneousExtensions.cs
@@ -2,24 +2,29 @@ using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Client.Http;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
-	public static class MiscellaneousExtensions {
-		public static string RemoveWhitespace(this string input) {
-			return new string(input.ToCharArray()
-				.Where(c => !char.IsWhiteSpace(c))
-				.ToArray());
-		}
+namespace GraphQL.Client.Tests.Common.Helpers
+{
+    public static class MiscellaneousExtensions
+    {
+        public static string RemoveWhitespace(this string input)
+        {
+            return new string(input.ToCharArray()
+                .Where(c => !char.IsWhiteSpace(c))
+                .ToArray());
+        }
 
-		public static CallbackMonitor<GraphQLHttpClient> ConfigureMonitorForOnWebsocketConnected(
-			this GraphQLHttpClient client) {
-			var tester = new CallbackMonitor<GraphQLHttpClient>();
-			client.Options.OnWebsocketConnected = c => {
-				tester.Invoke(c);
-				return Task.CompletedTask;
-			};
-			return tester;
-		}
+        public static CallbackMonitor<GraphQLHttpClient> ConfigureMonitorForOnWebsocketConnected(
+            this GraphQLHttpClient client)
+        {
+            var tester = new CallbackMonitor<GraphQLHttpClient>();
+            client.Options.OnWebsocketConnected = c =>
+            {
+                tester.Invoke(c);
+                return Task.CompletedTask;
+            };
+            return tester;
+        }
 
 
-	}
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/NetworkHelpers.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/NetworkHelpers.cs
@@ -1,14 +1,17 @@
 using System.Net;
 using System.Net.Sockets;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
-	public static class NetworkHelpers {
-		public static int GetFreeTcpPortNumber() {
-			var l = new TcpListener(IPAddress.Loopback, 0);
-			l.Start();
-			var port = ((IPEndPoint)l.LocalEndpoint).Port;
-			l.Stop();
-			return port;
-		}
-	}
+namespace GraphQL.Client.Tests.Common.Helpers
+{
+    public static class NetworkHelpers
+    {
+        public static int GetFreeTcpPortNumber()
+        {
+            var l = new TcpListener(IPAddress.Loopback, 0);
+            l.Start();
+            var port = ((IPEndPoint)l.LocalEndpoint).Port;
+            l.Stop();
+            return port;
+        }
+    }
 }

--- a/tests/GraphQL.Client.Tests.Common/Helpers/ObservableTester.cs
+++ b/tests/GraphQL.Client.Tests.Common/Helpers/ObservableTester.cs
@@ -7,159 +7,178 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
-namespace GraphQL.Client.Tests.Common.Helpers {
-	public class ObservableTester<TSubscriptionPayload> : IDisposable {
-		private readonly IDisposable subscription;
-		private readonly ManualResetEventSlim updateReceived = new ManualResetEventSlim();
-		private readonly ManualResetEventSlim completed = new ManualResetEventSlim();
-		private readonly ManualResetEventSlim error = new ManualResetEventSlim();
-		private readonly EventLoopScheduler observeScheduler = new EventLoopScheduler();
+namespace GraphQL.Client.Tests.Common.Helpers
+{
+    public class ObservableTester<TSubscriptionPayload> : IDisposable
+    {
+        private readonly IDisposable subscription;
+        private readonly ManualResetEventSlim updateReceived = new ManualResetEventSlim();
+        private readonly ManualResetEventSlim completed = new ManualResetEventSlim();
+        private readonly ManualResetEventSlim error = new ManualResetEventSlim();
+        private readonly EventLoopScheduler observeScheduler = new EventLoopScheduler();
 
-		/// <summary>
-		/// The timeout for <see cref="ShouldHaveReceivedUpdate"/>. Defaults to 1 s
-		/// </summary>
-		public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(3);
+        /// <summary>
+        /// The timeout for <see cref="ShouldHaveReceivedUpdate"/>. Defaults to 1 s
+        /// </summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(3);
 
-		/// <summary>
-		/// Indicates that an update has been received since the last <see cref="_reset"/>
-		/// </summary>
-		public bool UpdateReceived => updateReceived.IsSet;
-		/// <summary>
-		/// The last payload which was received.
-		/// </summary>
-		public TSubscriptionPayload LastPayload { get; private set; }
+        /// <summary>
+        /// Indicates that an update has been received since the last <see cref="_reset"/>
+        /// </summary>
+        public bool UpdateReceived => updateReceived.IsSet;
+        /// <summary>
+        /// The last payload which was received.
+        /// </summary>
+        public TSubscriptionPayload LastPayload { get; private set; }
 
-		public Exception Error { get; private set; }
+        public Exception Error { get; private set; }
 
-		/// <summary>
-		/// Creates a new <see cref="ObservableTester{T}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
-		/// </summary>
-		/// <param name="observable">the <see cref="IObservable{T}"/> under test</param>
-		public ObservableTester(IObservable<TSubscriptionPayload> observable) {
+        /// <summary>
+        /// Creates a new <see cref="ObservableTester{T}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
+        /// </summary>
+        /// <param name="observable">the <see cref="IObservable{T}"/> under test</param>
+        public ObservableTester(IObservable<TSubscriptionPayload> observable)
+        {
 
-			observeScheduler.Schedule(() =>
-				Debug.WriteLine($"Observe scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
+            observeScheduler.Schedule(() =>
+                Debug.WriteLine($"Observe scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
 
-			subscription = observable.ObserveOn(observeScheduler).Subscribe(
-				obj => {
-					Debug.WriteLine($"observable tester {GetHashCode()}: payload received");
-					LastPayload = obj;
-					updateReceived.Set();
-				},
-				ex => {
-					Debug.WriteLine($"observable tester {GetHashCode()} error received: {ex}");
-					Error = ex;
-					error.Set();
-				},
-				() => {
-					Debug.WriteLine($"observable tester {GetHashCode()}: completed");
-					completed.Set();
-				});
-		}
+            subscription = observable.ObserveOn(observeScheduler).Subscribe(
+                obj =>
+                {
+                    Debug.WriteLine($"observable tester {GetHashCode()}: payload received");
+                    LastPayload = obj;
+                    updateReceived.Set();
+                },
+                ex =>
+                {
+                    Debug.WriteLine($"observable tester {GetHashCode()} error received: {ex}");
+                    Error = ex;
+                    error.Set();
+                },
+                () =>
+                {
+                    Debug.WriteLine($"observable tester {GetHashCode()}: completed");
+                    completed.Set();
+                });
+        }
 
-		/// <summary>
-		/// Resets the tester class. Should be called before triggering the potential update
-		/// </summary>
-		private void Reset() {
-			updateReceived.Reset();
-		}
+        /// <summary>
+        /// Resets the tester class. Should be called before triggering the potential update
+        /// </summary>
+        private void Reset()
+        {
+            updateReceived.Reset();
+        }
 
-		/// <inheritdoc />
-		public void Dispose() {
-			subscription?.Dispose();
-			observeScheduler.Dispose();
-		}
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            subscription?.Dispose();
+            observeScheduler.Dispose();
+        }
 
-		public SubscriptionAssertions<TSubscriptionPayload> Should() {
-			return new SubscriptionAssertions<TSubscriptionPayload>(this);
-		}
+        public SubscriptionAssertions<TSubscriptionPayload> Should()
+        {
+            return new SubscriptionAssertions<TSubscriptionPayload>(this);
+        }
 
-		public class SubscriptionAssertions<TPayload> : ReferenceTypeAssertions<ObservableTester<TPayload>, SubscriptionAssertions<TPayload>> {
-			public SubscriptionAssertions(ObservableTester<TPayload> tester) {
-				Subject = tester;
-			}
+        public class SubscriptionAssertions<TPayload> : ReferenceTypeAssertions<ObservableTester<TPayload>, SubscriptionAssertions<TPayload>>
+        {
+            public SubscriptionAssertions(ObservableTester<TPayload> tester)
+            {
+                Subject = tester;
+            }
 
-			protected override string Identifier => "Subscription";
+            protected override string Identifier => "Subscription";
 
-			public AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload> HaveReceivedPayload(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => {
-						var isSet = Subject.updateReceived.Wait(timeout);
-						if(!isSet)
-							Debug.WriteLine($"waiting for payload on thread {Thread.CurrentThread.ManagedThreadId} timed out!");
-						return isSet;
-					})
-					.ForCondition(isSet => isSet)
-					.FailWith("Expected {context:Subscription} to receive new payload{reason}, but did not receive an update within {0}", timeout);
+            public AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload> HaveReceivedPayload(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() =>
+                    {
+                        var isSet = Subject.updateReceived.Wait(timeout);
+                        if (!isSet)
+                            Debug.WriteLine($"waiting for payload on thread {Thread.CurrentThread.ManagedThreadId} timed out!");
+                        return isSet;
+                    })
+                    .ForCondition(isSet => isSet)
+                    .FailWith("Expected {context:Subscription} to receive new payload{reason}, but did not receive an update within {0}", timeout);
 
-				Subject.updateReceived.Reset();
-				return new AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload>(this, Subject.LastPayload);
-			}
-			public AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload> HaveReceivedPayload(string because = "", params object[] becauseArgs)
-				=> HaveReceivedPayload(Subject.Timeout, because, becauseArgs);
+                Subject.updateReceived.Reset();
+                return new AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload>(this, Subject.LastPayload);
+            }
+            public AndWhichConstraint<SubscriptionAssertions<TPayload>, TPayload> HaveReceivedPayload(string because = "", params object[] becauseArgs)
+                => HaveReceivedPayload(Subject.Timeout, because, becauseArgs);
 
-			public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveReceivedPayload(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => Subject.updateReceived.Wait(timeout))
-					.ForCondition(isSet => !isSet)
-					.FailWith("Expected {context:Subscription} to not receive a new payload{reason}, but did receive an update: {0}", Subject.LastPayload);
+            public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveReceivedPayload(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() => Subject.updateReceived.Wait(timeout))
+                    .ForCondition(isSet => !isSet)
+                    .FailWith("Expected {context:Subscription} to not receive a new payload{reason}, but did receive an update: {0}", Subject.LastPayload);
 
-				Subject.updateReceived.Reset();
-				return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
-			}
-			public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveReceivedPayload(string because = "", params object[] becauseArgs)
-				=> NotHaveReceivedPayload(TimeSpan.FromMilliseconds(100), because, becauseArgs);
+                Subject.updateReceived.Reset();
+                return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
+            }
+            public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveReceivedPayload(string because = "", params object[] becauseArgs)
+                => NotHaveReceivedPayload(TimeSpan.FromMilliseconds(100), because, becauseArgs);
 
-			public AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception> HaveReceivedError(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => Subject.error.Wait(timeout))
-					.ForCondition(isSet => isSet)
-					.FailWith("Expected {context:Subscription} to fail{reason}, but did not receive an error within {0}", timeout);
+            public AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception> HaveReceivedError(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() => Subject.error.Wait(timeout))
+                    .ForCondition(isSet => isSet)
+                    .FailWith("Expected {context:Subscription} to fail{reason}, but did not receive an error within {0}", timeout);
 
-				return new AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception>(this, Subject.Error);
-			}
-			public AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception> HaveReceivedError(string because = "", params object[] becauseArgs)
-				=> HaveReceivedError(Subject.Timeout, because, becauseArgs);
+                return new AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception>(this, Subject.Error);
+            }
+            public AndWhichConstraint<SubscriptionAssertions<TPayload>, Exception> HaveReceivedError(string because = "", params object[] becauseArgs)
+                => HaveReceivedError(Subject.Timeout, because, becauseArgs);
 
 
-			public AndConstraint<SubscriptionAssertions<TPayload>> HaveCompleted(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => Subject.completed.Wait(timeout))
-					.ForCondition(isSet => isSet)
-					.FailWith("Expected {context:Subscription} to complete{reason}, but did not complete within {0}", timeout);
+            public AndConstraint<SubscriptionAssertions<TPayload>> HaveCompleted(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() => Subject.completed.Wait(timeout))
+                    .ForCondition(isSet => isSet)
+                    .FailWith("Expected {context:Subscription} to complete{reason}, but did not complete within {0}", timeout);
 
-				return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
-			}
-			public AndConstraint<SubscriptionAssertions<TPayload>> HaveCompleted(string because = "", params object[] becauseArgs)
-				=> HaveCompleted(Subject.Timeout, because, becauseArgs);
+                return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
+            }
+            public AndConstraint<SubscriptionAssertions<TPayload>> HaveCompleted(string because = "", params object[] becauseArgs)
+                => HaveCompleted(Subject.Timeout, because, becauseArgs);
 
-			public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveCompleted(TimeSpan timeout,
-				string because = "", params object[] becauseArgs) {
-				Execute.Assertion
-					.BecauseOf(because, becauseArgs)
-					.Given(() => Subject.completed.Wait(timeout))
-					.ForCondition(isSet => !isSet)
-					.FailWith("Expected {context:Subscription} not to complete within {0}{reason}, but it did!", timeout);
+            public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveCompleted(TimeSpan timeout,
+                string because = "", params object[] becauseArgs)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .Given(() => Subject.completed.Wait(timeout))
+                    .ForCondition(isSet => !isSet)
+                    .FailWith("Expected {context:Subscription} not to complete within {0}{reason}, but it did!", timeout);
 
-				return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
-			}
-			public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveCompleted(string because = "", params object[] becauseArgs)
-				=> NotHaveCompleted(Subject.Timeout, because, becauseArgs);
-		}
-	}
+                return new AndConstraint<SubscriptionAssertions<TPayload>>(this);
+            }
+            public AndConstraint<SubscriptionAssertions<TPayload>> NotHaveCompleted(string because = "", params object[] becauseArgs)
+                => NotHaveCompleted(Subject.Timeout, because, becauseArgs);
+        }
+    }
 
-	public static class ObservableExtensions {
-		public static ObservableTester<T> Monitor<T>(this IObservable<T> observable) {
-			return new ObservableTester<T>(observable);
-		}
-	}
+    public static class ObservableExtensions
+    {
+        public static ObservableTester<T> Monitor<T>(this IObservable<T> observable)
+        {
+            return new ObservableTester<T>(observable);
+        }
+    }
 
 }

--- a/tests/GraphQL.Client.Tests.Common/StarWars/StarWarsHumans.cs
+++ b/tests/GraphQL.Client.Tests.Common/StarWars/StarWarsHumans.cs
@@ -11,9 +11,6 @@ namespace GraphQL.Client.Tests.Common.StarWars
             yield return new object[] { 2, "Vader" };
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/tests/GraphQL.Client.Tests.Common/StarWars/StarWarsHumans.cs
+++ b/tests/GraphQL.Client.Tests.Common/StarWars/StarWarsHumans.cs
@@ -1,15 +1,19 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace GraphQL.Client.Tests.Common.StarWars {
-	public class StarWarsHumans: IEnumerable<object[]> {
-		public IEnumerator<object[]> GetEnumerator() {
-			yield return new object[] { 1, "Luke" };
-			yield return new object[] { 2, "Vader" };
-		}
+namespace GraphQL.Client.Tests.Common.StarWars
+{
+    public class StarWarsHumans : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { 1, "Luke" };
+            yield return new object[] { 2, "Vader" };
+        }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
-	}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/Extensions/WebApplicationFactoryExtensions.cs
+++ b/tests/GraphQL.Integration.Tests/Extensions/WebApplicationFactoryExtensions.cs
@@ -2,15 +2,18 @@ using System;
 using GraphQL.Client.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 
-namespace GraphQL.Integration.Tests.Extensions {
-	public static class WebApplicationFactoryExtensions {
-		public static GraphQLHttpClient CreateGraphQlHttpClient<TEntryPoint>(
-			this WebApplicationFactory<TEntryPoint> factory, string graphQlSchemaUrl, string urlScheme = "http://") where TEntryPoint : class {
-			var httpClient = factory.CreateClient();
-			var uriBuilder = new UriBuilder(httpClient.BaseAddress);
-			uriBuilder.Path = graphQlSchemaUrl;
-			uriBuilder.Scheme = urlScheme;
-			return httpClient.AsGraphQLClient(uriBuilder.Uri);
-		}
-	}
+namespace GraphQL.Integration.Tests.Extensions
+{
+    public static class WebApplicationFactoryExtensions
+    {
+        public static GraphQLHttpClient CreateGraphQlHttpClient<TEntryPoint>(
+            this WebApplicationFactory<TEntryPoint> factory, string graphQlSchemaUrl, string urlScheme = "http://") where TEntryPoint : class
+        {
+            var httpClient = factory.CreateClient();
+            var uriBuilder = new UriBuilder(httpClient.BaseAddress);
+            uriBuilder.Path = graphQlSchemaUrl;
+            uriBuilder.Scheme = urlScheme;
+            return httpClient.AsGraphQLClient(uriBuilder.Uri);
+        }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
@@ -39,10 +39,10 @@ namespace GraphQL.Integration.Tests.Helpers
         }
 
         public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
-            => GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
+            => GetGraphQLClient(Common.STAR_WARS_ENDPOINT, requestsViaWebsocket);
 
         public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
-            => GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
+            => GetGraphQLClient(Common.CHAT_ENDPOINT, requestsViaWebsocket);
 
         private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
         {

--- a/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
@@ -8,49 +8,57 @@ using GraphQL.Client.Tests.Common;
 using GraphQL.Client.Tests.Common.Helpers;
 using Microsoft.AspNetCore.Hosting;
 
-namespace GraphQL.Integration.Tests.Helpers {
-	public abstract class IntegrationServerTestFixture {
-		public int Port { get; private set; }
-		public IWebHost Server { get; private set; }
-		public abstract IGraphQLWebsocketJsonSerializer Serializer { get; }
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public abstract class IntegrationServerTestFixture
+    {
+        public int Port { get; private set; }
+        public IWebHost Server { get; private set; }
+        public abstract IGraphQLWebsocketJsonSerializer Serializer { get; }
 
-		public IntegrationServerTestFixture()
-		{
-			Port = NetworkHelpers.GetFreeTcpPortNumber();
-		}
+        public IntegrationServerTestFixture()
+        {
+            Port = NetworkHelpers.GetFreeTcpPortNumber();
+        }
 
-		public async Task CreateServer() {
-			if (Server != null) return;
-			Server = await WebHostHelpers.CreateServer(Port);
-		}
+        public async Task CreateServer()
+        {
+            if (Server != null)
+                return;
+            Server = await WebHostHelpers.CreateServer(Port);
+        }
 
-		public async Task ShutdownServer() {
-			if (Server == null)
-				return;
+        public async Task ShutdownServer()
+        {
+            if (Server == null)
+                return;
 
-			await Server.StopAsync();
-			Server.Dispose();
-			Server = null;
-		}
+            await Server.StopAsync();
+            Server.Dispose();
+            Server = null;
+        }
 
-		public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
-			=> GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
+        public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
+            => GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
 
-		public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
-			=> GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
+        public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
+            => GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
 
-		private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false) {
-			if(Serializer == null)
-				throw new InvalidOperationException("JSON serializer not configured");
-			return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket, Serializer);
-		}
-	}
+        private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
+        {
+            if (Serializer == null)
+                throw new InvalidOperationException("JSON serializer not configured");
+            return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket, Serializer);
+        }
+    }
 
-	public class NewtonsoftIntegrationServerTestFixture: IntegrationServerTestFixture {
-		public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new NewtonsoftJsonSerializer();
-	}
+    public class NewtonsoftIntegrationServerTestFixture : IntegrationServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new NewtonsoftJsonSerializer();
+    }
 
-	public class SystemTextJsonIntegrationServerTestFixture : IntegrationServerTestFixture {
-		public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new SystemTextJsonSerializer();
-	}
+    public class SystemTextJsonIntegrationServerTestFixture : IntegrationServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new SystemTextJsonSerializer();
+    }
 }

--- a/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
@@ -15,63 +15,67 @@ using Microsoft.Extensions.Logging;
 
 namespace GraphQL.Integration.Tests.Helpers
 {
-	public static class WebHostHelpers
-	{
-		public static async Task<IWebHost> CreateServer(int port)
-		{
-			var configBuilder = new ConfigurationBuilder();
-			configBuilder.AddInMemoryCollection();
-			var config = configBuilder.Build();
-			config["server.urls"] = $"http://localhost:{port}";
+    public static class WebHostHelpers
+    {
+        public static async Task<IWebHost> CreateServer(int port)
+        {
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.AddInMemoryCollection();
+            var config = configBuilder.Build();
+            config["server.urls"] = $"http://localhost:{port}";
 
-			var host = new WebHostBuilder()
-				.ConfigureLogging((ctx, logging) => {
-					logging.AddDebug();
-				})
-				.UseConfiguration(config)
-				.UseKestrel()
-				.UseStartup<Startup>()
-				.Build();
+            var host = new WebHostBuilder()
+                .ConfigureLogging((ctx, logging) =>
+                {
+                    logging.AddDebug();
+                })
+                .UseConfiguration(config)
+                .UseKestrel()
+                .UseStartup<Startup>()
+                .Build();
 
-			var tcs = new TaskCompletionSource<bool>();
-			host.Services.GetService<IHostApplicationLifetime>().ApplicationStarted.Register(() => tcs.TrySetResult(true));
-			await host.StartAsync();
-			await tcs.Task;
-			return host;
-		}
-		
-		public static GraphQLHttpClient GetGraphQLClient(int port, string endpoint, bool requestsViaWebsocket = false, IGraphQLWebsocketJsonSerializer serializer = null)
-			=> new GraphQLHttpClient(new GraphQLHttpClientOptions {
-				EndPoint = new Uri($"http://localhost:{port}{endpoint}"),
-				UseWebSocketForQueriesAndMutations = requestsViaWebsocket,
-				JsonSerializer = serializer ?? new NewtonsoftJsonSerializer()
-			});
-	}
+            var tcs = new TaskCompletionSource<bool>();
+            host.Services.GetService<IHostApplicationLifetime>().ApplicationStarted.Register(() => tcs.TrySetResult(true));
+            await host.StartAsync();
+            await tcs.Task;
+            return host;
+        }
 
-	public class TestServerSetup : IDisposable
-	{
-		public TestServerSetup(IGraphQLWebsocketJsonSerializer serializer) {
-			this.serializer = serializer;
-			Port = NetworkHelpers.GetFreeTcpPortNumber();
-		}
+        public static GraphQLHttpClient GetGraphQLClient(int port, string endpoint, bool requestsViaWebsocket = false, IGraphQLWebsocketJsonSerializer serializer = null)
+            => new GraphQLHttpClient(new GraphQLHttpClientOptions
+            {
+                EndPoint = new Uri($"http://localhost:{port}{endpoint}"),
+                UseWebSocketForQueriesAndMutations = requestsViaWebsocket,
+                JsonSerializer = serializer ?? new NewtonsoftJsonSerializer()
+            });
+    }
 
-		public int Port { get; }
-		public IWebHost Server { get; set; }
-		public IGraphQLWebsocketJsonSerializer serializer { get; set; }
+    public class TestServerSetup : IDisposable
+    {
+        public TestServerSetup(IGraphQLWebsocketJsonSerializer serializer)
+        {
+            this.serializer = serializer;
+            Port = NetworkHelpers.GetFreeTcpPortNumber();
+        }
 
-		public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
-			=> GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
+        public int Port { get; }
+        public IWebHost Server { get; set; }
+        public IGraphQLWebsocketJsonSerializer serializer { get; set; }
 
-		public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
-			=> GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
+        public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
+            => GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
 
-		private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false) {
-			return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket);
-		}
+        public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
+            => GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
 
-		public void Dispose()
-		{
-			Server?.Dispose();
-		}
-	}
+        private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
+        {
+            return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket);
+        }
+
+        public void Dispose()
+        {
+            Server?.Dispose();
+        }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/WebHostHelpers.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using GraphQL.Client.Abstractions.Websocket;
 using GraphQL.Client.Http;
@@ -25,10 +24,7 @@ namespace GraphQL.Integration.Tests.Helpers
             config["server.urls"] = $"http://localhost:{port}";
 
             var host = new WebHostBuilder()
-                .ConfigureLogging((ctx, logging) =>
-                {
-                    logging.AddDebug();
-                })
+                .ConfigureLogging((ctx, logging) => logging.AddDebug())
                 .UseConfiguration(config)
                 .UseKestrel()
                 .UseStartup<Startup>()
@@ -54,28 +50,22 @@ namespace GraphQL.Integration.Tests.Helpers
     {
         public TestServerSetup(IGraphQLWebsocketJsonSerializer serializer)
         {
-            this.serializer = serializer;
+            Serializer = serializer;
             Port = NetworkHelpers.GetFreeTcpPortNumber();
         }
 
         public int Port { get; }
         public IWebHost Server { get; set; }
-        public IGraphQLWebsocketJsonSerializer serializer { get; set; }
+        public IGraphQLWebsocketJsonSerializer Serializer { get; set; }
 
         public GraphQLHttpClient GetStarWarsClient(bool requestsViaWebsocket = false)
-            => GetGraphQLClient(Common.StarWarsEndpoint, requestsViaWebsocket);
+            => GetGraphQLClient(Common.STAR_WARS_ENDPOINT, requestsViaWebsocket);
 
         public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
-            => GetGraphQLClient(Common.ChatEndpoint, requestsViaWebsocket);
+            => GetGraphQLClient(Common.CHAT_ENDPOINT, requestsViaWebsocket);
 
-        private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
-        {
-            return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket);
-        }
+        private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false) => WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket);
 
-        public void Dispose()
-        {
-            Server?.Dispose();
-        }
+        public void Dispose() => Server?.Dispose();
     }
 }

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Base.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Base.cs
@@ -14,91 +14,101 @@ using GraphQL.Integration.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace GraphQL.Integration.Tests.QueryAndMutationTests {
+namespace GraphQL.Integration.Tests.QueryAndMutationTests
+{
 
-	public abstract class Base: IAsyncLifetime {
+    public abstract class Base : IAsyncLifetime
+    {
 
-		protected IntegrationServerTestFixture Fixture;
-		protected GraphQLHttpClient StarWarsClient;
-		protected GraphQLHttpClient ChatClient;
+        protected IntegrationServerTestFixture Fixture;
+        protected GraphQLHttpClient StarWarsClient;
+        protected GraphQLHttpClient ChatClient;
 
-		protected Base(IntegrationServerTestFixture fixture) {
-			Fixture = fixture;
-		}
+        protected Base(IntegrationServerTestFixture fixture)
+        {
+            Fixture = fixture;
+        }
 
-		public async Task InitializeAsync() {
-			await Fixture.CreateServer();
-			StarWarsClient = Fixture.GetStarWarsClient();
-			ChatClient = Fixture.GetChatClient();
-		}
+        public async Task InitializeAsync()
+        {
+            await Fixture.CreateServer();
+            StarWarsClient = Fixture.GetStarWarsClient();
+            ChatClient = Fixture.GetChatClient();
+        }
 
-		public Task DisposeAsync() {
-			ChatClient?.Dispose();
-			StarWarsClient?.Dispose();
-			return Task.CompletedTask;
-		}
+        public Task DisposeAsync()
+        {
+            ChatClient?.Dispose();
+            StarWarsClient?.Dispose();
+            return Task.CompletedTask;
+        }
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void QueryTheory(int id, string name) {
-			var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty }});
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void QueryTheory(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
 
-			Assert.Null(response.Errors);
-			Assert.Equal(name, response.Data.Human.Name);
-		}
+            Assert.Null(response.Errors);
+            Assert.Equal(name, response.Data.Human.Name);
+        }
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void QueryAsHttpResponseTheory(int id, string name) {
-			var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
-			var responseType = new {Human = new {Name = string.Empty}};
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => responseType );
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void QueryAsHttpResponseTheory(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
+            var responseType = new { Human = new { Name = string.Empty } };
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => responseType);
 
-			FluentActions.Invoking(() => response.AsGraphQLHttpResponse()).Should()
-				.NotThrow("because the returned object is a GraphQLHttpResponse");
+            FluentActions.Invoking(() => response.AsGraphQLHttpResponse()).Should()
+                .NotThrow("because the returned object is a GraphQLHttpResponse");
 
-			var httpResponse = response.AsGraphQLHttpResponse();
+            var httpResponse = response.AsGraphQLHttpResponse();
 
-			httpResponse.Errors.Should().BeNull();
-			httpResponse.Data.Human.Name.Should().Be(name);
+            httpResponse.Errors.Should().BeNull();
+            httpResponse.Data.Human.Name.Should().Be(name);
 
-			httpResponse.StatusCode.Should().BeEquivalentTo(HttpStatusCode.OK);
-			httpResponse.ResponseHeaders.Date.Should().BeCloseTo(DateTimeOffset.Now, TimeSpan.FromMinutes(1));
-		}
+            httpResponse.StatusCode.Should().BeEquivalentTo(HttpStatusCode.OK);
+            httpResponse.ResponseHeaders.Date.Should().BeCloseTo(DateTimeOffset.Now, TimeSpan.FromMinutes(1));
+        }
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void QueryWithDynamicReturnTypeTheory(int id, string name) {
-			var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void QueryWithDynamicReturnTypeTheory(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest($"{{ human(id: \"{id}\") {{ name }} }}");
 
-			var response = await StarWarsClient.SendQueryAsync<dynamic>(graphQLRequest);
+            var response = await StarWarsClient.SendQueryAsync<dynamic>(graphQLRequest);
 
-			Assert.Null(response.Errors);
-			Assert.Equal(name, response.Data.human.name.ToString());
-		}
+            Assert.Null(response.Errors);
+            Assert.Equal(name, response.Data.human.name.ToString());
+        }
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void QueryWitVarsTheory(int id, string name) {
-			var graphQLRequest = new GraphQLRequest(@"
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void QueryWitVarsTheory(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				query Human($id: String!){
 					human(id: $id) {
 						name
 					}
 				}",
-				new {id = id.ToString()});
+                new { id = id.ToString() });
 
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
 
-			Assert.Null(response.Errors);
-			Assert.Equal(name, response.Data.Human.Name);
-		}
+            Assert.Null(response.Errors);
+            Assert.Equal(name, response.Data.Human.Name);
+        }
 
-		[Theory]
-		[ClassData(typeof(StarWarsHumans))]
-		public async void QueryWitVarsAndOperationNameTheory(int id, string name) {
-			var graphQLRequest = new GraphQLRequest(@"
+        [Theory]
+        [ClassData(typeof(StarWarsHumans))]
+        public async void QueryWitVarsAndOperationNameTheory(int id, string name)
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				query Human($id: String!){
 					human(id: $id) {
 						name
@@ -110,18 +120,19 @@ namespace GraphQL.Integration.Tests.QueryAndMutationTests {
 				    name
 				  }
 				}",
-				new { id = id.ToString() },
-				"Human");
+                new { id = id.ToString() },
+                "Human");
 
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
 
-			Assert.Null(response.Errors);
-			Assert.Equal(name, response.Data.Human.Name);
-		}
+            Assert.Null(response.Errors);
+            Assert.Equal(name, response.Data.Human.Name);
+        }
 
-		[Fact]
-		public async void SendMutationFact() {
-			var mutationRequest = new GraphQLRequest(@"
+        [Fact]
+        public async void SendMutationFact()
+        {
+            var mutationRequest = new GraphQLRequest(@"
 				mutation CreateHuman($human: HumanInput!) {
 				  createHuman(human: $human) {
 				    id
@@ -129,84 +140,89 @@ namespace GraphQL.Integration.Tests.QueryAndMutationTests {
 				    homePlanet
 				  }
 				}",
-				new { human = new { name = "Han Solo", homePlanet = "Corellia"}});
+                new { human = new { name = "Han Solo", homePlanet = "Corellia" } });
 
-			var queryRequest = new GraphQLRequest(@"
+            var queryRequest = new GraphQLRequest(@"
 				query Human($id: String!){
 					human(id: $id) {
 						name
 					}
 				}");
 
-			var mutationResponse = await StarWarsClient.SendMutationAsync(mutationRequest, () => new {
-					createHuman = new {
-						Id = "",
-						Name = "",
-						HomePlanet = ""
-					}
-				});
+            var mutationResponse = await StarWarsClient.SendMutationAsync(mutationRequest, () => new
+            {
+                createHuman = new
+                {
+                    Id = "",
+                    Name = "",
+                    HomePlanet = ""
+                }
+            });
 
-			Assert.Null(mutationResponse.Errors);
-			Assert.Equal("Han Solo", mutationResponse.Data.createHuman.Name);
-			Assert.Equal("Corellia", mutationResponse.Data.createHuman.HomePlanet);
+            Assert.Null(mutationResponse.Errors);
+            Assert.Equal("Han Solo", mutationResponse.Data.createHuman.Name);
+            Assert.Equal("Corellia", mutationResponse.Data.createHuman.HomePlanet);
 
-			queryRequest.Variables = new {id = mutationResponse.Data.createHuman.Id};
-			var queryResponse = await StarWarsClient.SendQueryAsync(queryRequest, () => new { Human = new { Name = string.Empty } });
-			
-			Assert.Null(queryResponse.Errors);
-			Assert.Equal("Han Solo", queryResponse.Data.Human.Name);
-		}
+            queryRequest.Variables = new { id = mutationResponse.Data.createHuman.Id };
+            var queryResponse = await StarWarsClient.SendQueryAsync(queryRequest, () => new { Human = new { Name = string.Empty } });
 
-		[Fact]
-		public async void PreprocessHttpRequestMessageIsCalled() {
-			var callbackTester = new CallbackMonitor<HttpRequestMessage>();
-			var graphQLRequest = new GraphQLHttpRequest($"{{ human(id: \"1\") {{ name }} }}") {
-				PreprocessHttpRequestMessage = callbackTester.Invoke
-			};
+            Assert.Null(queryResponse.Errors);
+            Assert.Equal("Han Solo", queryResponse.Data.Human.Name);
+        }
 
-			var defaultHeaders = StarWarsClient.HttpClient.DefaultRequestHeaders;
-			var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
-			callbackTester.Should().HaveBeenInvokedWithPayload().Which.Headers.Should().BeEquivalentTo(defaultHeaders);
-			Assert.Null(response.Errors);
-			Assert.Equal("Luke", response.Data.Human.Name);
-		}
+        [Fact]
+        public async void PreprocessHttpRequestMessageIsCalled()
+        {
+            var callbackTester = new CallbackMonitor<HttpRequestMessage>();
+            var graphQLRequest = new GraphQLHttpRequest($"{{ human(id: \"1\") {{ name }} }}")
+            {
+                PreprocessHttpRequestMessage = callbackTester.Invoke
+            };
 
-		[Fact]
-		public void PostRequestCanBeCancelled() {
-			var graphQLRequest = new GraphQLRequest(@"
+            var defaultHeaders = StarWarsClient.HttpClient.DefaultRequestHeaders;
+            var response = await StarWarsClient.SendQueryAsync(graphQLRequest, () => new { Human = new { Name = string.Empty } });
+            callbackTester.Should().HaveBeenInvokedWithPayload().Which.Headers.Should().BeEquivalentTo(defaultHeaders);
+            Assert.Null(response.Errors);
+            Assert.Equal("Luke", response.Data.Human.Name);
+        }
+
+        [Fact]
+        public void PostRequestCanBeCancelled()
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				query Long {
 					longRunning
 				}");
 
-			var chatQuery = Fixture.Server.Services.GetService<ChatQuery>();
-			var cts = new CancellationTokenSource();
+            var chatQuery = Fixture.Server.Services.GetService<ChatQuery>();
+            var cts = new CancellationTokenSource();
 
-			var request =
-				ConcurrentTaskWrapper.New(() => ChatClient.SendQueryAsync(graphQLRequest, () => new { longRunning = string.Empty }, cts.Token));
+            var request =
+                ConcurrentTaskWrapper.New(() => ChatClient.SendQueryAsync(graphQLRequest, () => new { longRunning = string.Empty }, cts.Token));
 
-			// Test regular request
-			// start request
-			request.Start();
-			// wait until the query has reached the server
-			chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
-			// unblock the query
-			chatQuery.LongRunningQueryBlocker.Set();
-			// check execution time
-			request.Invoke().Result.Data.longRunning.Should().Be("finally returned");
+            // Test regular request
+            // start request
+            request.Start();
+            // wait until the query has reached the server
+            chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
+            // unblock the query
+            chatQuery.LongRunningQueryBlocker.Set();
+            // check execution time
+            request.Invoke().Result.Data.longRunning.Should().Be("finally returned");
 
-			// reset stuff
-			chatQuery.LongRunningQueryBlocker.Reset();
-			request.Clear();
+            // reset stuff
+            chatQuery.LongRunningQueryBlocker.Reset();
+            request.Clear();
 
-			// cancellation test
-			request.Start();
-			chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
-			cts.Cancel();
-			request.Invoking().Should().Throw<TaskCanceledException>("because the request was cancelled");
+            // cancellation test
+            request.Start();
+            chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
+            cts.Cancel();
+            request.Invoking().Should().Throw<TaskCanceledException>("because the request was cancelled");
 
-			// let the server finish its query
-			chatQuery.LongRunningQueryBlocker.Set();
-		}
+            // let the server finish its query
+            chatQuery.LongRunningQueryBlocker.Set();
+        }
 
-	}
+    }
 }

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Base.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Base.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Extensions;
 using GraphQL.Client.Abstractions;
 using GraphQL.Client.Http;
 using GraphQL.Client.Tests.Common.Chat.Schema;

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Newtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Newtonsoft.cs
@@ -2,10 +2,12 @@ using GraphQL.Client.Serializer.Newtonsoft;
 using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 
-namespace GraphQL.Integration.Tests.QueryAndMutationTests {
-	public class Newtonsoft: Base, IClassFixture<NewtonsoftIntegrationServerTestFixture> {
-		public Newtonsoft(NewtonsoftIntegrationServerTestFixture fixture) : base(fixture)
-		{
-		}
-	}
+namespace GraphQL.Integration.Tests.QueryAndMutationTests
+{
+    public class Newtonsoft : Base, IClassFixture<NewtonsoftIntegrationServerTestFixture>
+    {
+        public Newtonsoft(NewtonsoftIntegrationServerTestFixture fixture) : base(fixture)
+        {
+        }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Newtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/Newtonsoft.cs
@@ -1,4 +1,3 @@
-using GraphQL.Client.Serializer.Newtonsoft;
 using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/SystemTextJson.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/SystemTextJson.cs
@@ -1,4 +1,3 @@
-using GraphQL.Client.Serializer.SystemTextJson;
 using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 

--- a/tests/GraphQL.Integration.Tests/QueryAndMutationTests/SystemTextJson.cs
+++ b/tests/GraphQL.Integration.Tests/QueryAndMutationTests/SystemTextJson.cs
@@ -2,10 +2,12 @@ using GraphQL.Client.Serializer.SystemTextJson;
 using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 
-namespace GraphQL.Integration.Tests.QueryAndMutationTests {
-	public class SystemTextJson: Base, IClassFixture<SystemTextJsonIntegrationServerTestFixture> {
-		public SystemTextJson(SystemTextJsonIntegrationServerTestFixture fixture) : base(fixture)
-		{
-		}
-	}
+namespace GraphQL.Integration.Tests.QueryAndMutationTests
+{
+    public class SystemTextJson : Base, IClassFixture<SystemTextJsonIntegrationServerTestFixture>
+    {
+        public SystemTextJson(SystemTextJsonIntegrationServerTestFixture fixture) : base(fixture)
+        {
+        }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
@@ -17,184 +17,198 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace GraphQL.Integration.Tests.WebsocketTests {
-	public abstract class Base: IAsyncLifetime {
-		protected readonly ITestOutputHelper Output;
-		protected readonly IntegrationServerTestFixture Fixture;
-		protected GraphQLHttpClient ChatClient;
-		
-		protected Base(ITestOutputHelper output, IntegrationServerTestFixture fixture) {
-			this.Output = output;
-			this.Fixture = fixture;
-		}
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public abstract class Base : IAsyncLifetime
+    {
+        protected readonly ITestOutputHelper Output;
+        protected readonly IntegrationServerTestFixture Fixture;
+        protected GraphQLHttpClient ChatClient;
 
-		protected static ReceivedMessage InitialMessage = new ReceivedMessage {
-			Content = "initial message",
-			SentAt = DateTime.Now,
-			FromId = "1"
-		};
+        protected Base(ITestOutputHelper output, IntegrationServerTestFixture fixture)
+        {
+            this.Output = output;
+            this.Fixture = fixture;
+        }
 
-		public async Task InitializeAsync() {
-			await Fixture.CreateServer();
-			// make sure the buffer always contains the same message
-			Fixture.Server.Services.GetService<Chat>().AddMessage(InitialMessage);
+        protected static ReceivedMessage InitialMessage = new ReceivedMessage
+        {
+            Content = "initial message",
+            SentAt = DateTime.Now,
+            FromId = "1"
+        };
 
-			if (ChatClient == null) {
-				// then create the chat client
-				ChatClient = Fixture.GetChatClient(true);
-			}
-		}
+        public async Task InitializeAsync()
+        {
+            await Fixture.CreateServer();
+            // make sure the buffer always contains the same message
+            Fixture.Server.Services.GetService<Chat>().AddMessage(InitialMessage);
 
-		public Task DisposeAsync() {
-			ChatClient?.Dispose();
-			return Task.CompletedTask;
-		}
+            if (ChatClient == null)
+            {
+                // then create the chat client
+                ChatClient = Fixture.GetChatClient(true);
+            }
+        }
 
-		[Fact]
-		public async void CanSendRequestViaWebsocket() {
-			await ChatClient.InitializeWebsocketConnection();
-			const string message = "some random testing message";
-			var response = await ChatClient.AddMessageAsync(message);
-			response.Data.AddMessage.Content.Should().Be(message);
-		}
+        public Task DisposeAsync()
+        {
+            ChatClient?.Dispose();
+            return Task.CompletedTask;
+        }
 
-		[Fact]
-		public async void WebsocketRequestCanBeCancelled() {
-			var graphQLRequest = new GraphQLRequest(@"
+        [Fact]
+        public async void CanSendRequestViaWebsocket()
+        {
+            await ChatClient.InitializeWebsocketConnection();
+            const string message = "some random testing message";
+            var response = await ChatClient.AddMessageAsync(message);
+            response.Data.AddMessage.Content.Should().Be(message);
+        }
+
+        [Fact]
+        public async void WebsocketRequestCanBeCancelled()
+        {
+            var graphQLRequest = new GraphQLRequest(@"
 				query Long {
 					longRunning
 				}");
 
-			var chatQuery = Fixture.Server.Services.GetService<ChatQuery>();
-			var cts = new CancellationTokenSource();
+            var chatQuery = Fixture.Server.Services.GetService<ChatQuery>();
+            var cts = new CancellationTokenSource();
 
-			await ChatClient.InitializeWebsocketConnection();
-			var request =
-				ConcurrentTaskWrapper.New(() => ChatClient.SendQueryAsync(graphQLRequest, () => new { longRunning = string.Empty }, cts.Token));
+            await ChatClient.InitializeWebsocketConnection();
+            var request =
+                ConcurrentTaskWrapper.New(() => ChatClient.SendQueryAsync(graphQLRequest, () => new { longRunning = string.Empty }, cts.Token));
 
-			// Test regular request
-			// start request
-			request.Start();
-			// wait until the query has reached the server
-			chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
-			// unblock the query
-			chatQuery.LongRunningQueryBlocker.Set();
-			// check execution time
-			request.Invoke().Result.Data.longRunning.Should().Be("finally returned");
+            // Test regular request
+            // start request
+            request.Start();
+            // wait until the query has reached the server
+            chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
+            // unblock the query
+            chatQuery.LongRunningQueryBlocker.Set();
+            // check execution time
+            request.Invoke().Result.Data.longRunning.Should().Be("finally returned");
 
-			// reset stuff
-			chatQuery.LongRunningQueryBlocker.Reset();
-			request.Clear();
+            // reset stuff
+            chatQuery.LongRunningQueryBlocker.Reset();
+            request.Clear();
 
-			// cancellation test
-			request.Start();
-			chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
-			cts.Cancel();
-			request.Invoking().Should().Throw<TaskCanceledException>("because the request was cancelled");
+            // cancellation test
+            request.Start();
+            chatQuery.WaitingOnQueryBlocker.Wait(1000).Should().BeTrue("because the request should have reached the server by then");
+            cts.Cancel();
+            request.Invoking().Should().Throw<TaskCanceledException>("because the request was cancelled");
 
-			// let the server finish its query
-			chatQuery.LongRunningQueryBlocker.Set();
-		}
-		
-		[Fact]
-		public async void CanHandleRequestErrorViaWebsocket() {
-			await ChatClient.InitializeWebsocketConnection();
-			var response = await ChatClient.SendQueryAsync<object>("this query is formatted quite badly");
-			response.Errors.Should().ContainSingle("because the query is invalid");
-		}
+            // let the server finish its query
+            chatQuery.LongRunningQueryBlocker.Set();
+        }
 
-		private const string SubscriptionQuery = @"
+        [Fact]
+        public async void CanHandleRequestErrorViaWebsocket()
+        {
+            await ChatClient.InitializeWebsocketConnection();
+            var response = await ChatClient.SendQueryAsync<object>("this query is formatted quite badly");
+            response.Errors.Should().ContainSingle("because the query is invalid");
+        }
+
+        private const string SubscriptionQuery = @"
 			subscription {
 			  messageAdded{
 			    content
 			  }
 			}";
 
-		private readonly GraphQLRequest SubscriptionRequest = new GraphQLRequest(SubscriptionQuery);
+        private readonly GraphQLRequest SubscriptionRequest = new GraphQLRequest(SubscriptionQuery);
 
 
-		[Fact]
-		public async void CanCreateObservableSubscription() {
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-			await ChatClient.InitializeWebsocketConnection();
-			callbackMonitor.Should().HaveBeenInvokedWithPayload();
+        [Fact]
+        public async void CanCreateObservableSubscription()
+        {
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            await ChatClient.InitializeWebsocketConnection();
+            callbackMonitor.Should().HaveBeenInvokedWithPayload();
 
-			Debug.WriteLine("creating subscription stream");
-			var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
+            Debug.WriteLine("creating subscription stream");
+            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
 
-			Debug.WriteLine("subscribing...");
-			using var tester = observable.Monitor();
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+            Debug.WriteLine("subscribing...");
+            using var tester = observable.Monitor();
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
 
-			const string message1 = "Hello World";
-			var response = await ChatClient.AddMessageAsync(message1);
-			response.Data.AddMessage.Content.Should().Be(message1);
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
+            const string message1 = "Hello World";
+            var response = await ChatClient.AddMessageAsync(message1);
+            response.Data.AddMessage.Content.Should().Be(message1);
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
 
-			const string message2 = "lorem ipsum dolor si amet";
-			response = await ChatClient.AddMessageAsync(message2);
-			response.Data.AddMessage.Content.Should().Be(message2);
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
+            const string message2 = "lorem ipsum dolor si amet";
+            response = await ChatClient.AddMessageAsync(message2);
+            response.Data.AddMessage.Content.Should().Be(message2);
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
 
-			// disposing the client should throw a TaskCanceledException on the subscription
-			ChatClient.Dispose();
-			tester.Should().HaveCompleted();
-		}
+            // disposing the client should throw a TaskCanceledException on the subscription
+            ChatClient.Dispose();
+            tester.Should().HaveCompleted();
+        }
 
-		public class MessageAddedSubscriptionResult {
-			public MessageAddedContent MessageAdded { get; set; }
+        public class MessageAddedSubscriptionResult
+        {
+            public MessageAddedContent MessageAdded { get; set; }
 
-			public class MessageAddedContent {
-				public string Content { get; set; }
-			}
-		}
+            public class MessageAddedContent
+            {
+                public string Content { get; set; }
+            }
+        }
 
 
-		[Fact]
-		public async void CanReconnectWithSameObservable() {
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+        [Fact]
+        public async void CanReconnectWithSameObservable()
+        {
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
 
-			Debug.WriteLine("creating subscription stream");
-			var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
+            Debug.WriteLine("creating subscription stream");
+            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
 
-			Debug.WriteLine("subscribing...");
-			var tester = observable.Monitor();
-			callbackMonitor.Should().HaveBeenInvokedWithPayload();
-			await ChatClient.InitializeWebsocketConnection();
-			Debug.WriteLine("websocket connection initialized");
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+            Debug.WriteLine("subscribing...");
+            var tester = observable.Monitor();
+            callbackMonitor.Should().HaveBeenInvokedWithPayload();
+            await ChatClient.InitializeWebsocketConnection();
+            Debug.WriteLine("websocket connection initialized");
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
 
-			const string message1 = "Hello World";
-			Debug.WriteLine($"adding message {message1}");
-			var response = await ChatClient.AddMessageAsync(message1).ConfigureAwait(true);
-			response.Data.AddMessage.Content.Should().Be(message1);
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
+            const string message1 = "Hello World";
+            Debug.WriteLine($"adding message {message1}");
+            var response = await ChatClient.AddMessageAsync(message1).ConfigureAwait(true);
+            response.Data.AddMessage.Content.Should().Be(message1);
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
 
-			const string message2 = "How are you?";
-			response = await ChatClient.AddMessageAsync(message2).ConfigureAwait(true);
-			response.Data.AddMessage.Content.Should().Be(message2);
-			tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
+            const string message2 = "How are you?";
+            response = await ChatClient.AddMessageAsync(message2).ConfigureAwait(true);
+            response.Data.AddMessage.Content.Should().Be(message2);
+            tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
 
-			Debug.WriteLine("disposing subscription...");
-			tester.Dispose(); // does not close the websocket connection
+            Debug.WriteLine("disposing subscription...");
+            tester.Dispose(); // does not close the websocket connection
 
-			Debug.WriteLine($"creating new subscription from thread {Thread.CurrentThread.ManagedThreadId} ...");
-			var tester2 = observable.Monitor();
-			Debug.WriteLine($"waiting for payload on {Thread.CurrentThread.ManagedThreadId} ...");
-			tester2.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
+            Debug.WriteLine($"creating new subscription from thread {Thread.CurrentThread.ManagedThreadId} ...");
+            var tester2 = observable.Monitor();
+            Debug.WriteLine($"waiting for payload on {Thread.CurrentThread.ManagedThreadId} ...");
+            tester2.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message2);
 
-			const string message3 = "lorem ipsum dolor si amet";
-			response = await ChatClient.AddMessageAsync(message3).ConfigureAwait(true);
-			response.Data.AddMessage.Content.Should().Be(message3);
-			tester2.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message3);
+            const string message3 = "lorem ipsum dolor si amet";
+            response = await ChatClient.AddMessageAsync(message3).ConfigureAwait(true);
+            response.Data.AddMessage.Content.Should().Be(message3);
+            tester2.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message3);
 
-			// disposing the client should complete the subscription
-			ChatClient.Dispose();
-			tester2.Should().HaveCompleted();
-			tester2.Dispose();
-		}
+            // disposing the client should complete the subscription
+            ChatClient.Dispose();
+            tester2.Should().HaveCompleted();
+            tester2.Dispose();
+        }
 
-		private const string SubscriptionQuery2 = @"
+        private const string SubscriptionQuery2 = @"
 			subscription {
 			  userJoined{
 				displayName
@@ -202,188 +216,198 @@ namespace GraphQL.Integration.Tests.WebsocketTests {
 			  }
 			}";
 
-		public class UserJoinedSubscriptionResult {
-			public UserJoinedContent UserJoined { get; set; }
+        public class UserJoinedSubscriptionResult
+        {
+            public UserJoinedContent UserJoined { get; set; }
 
-			public class UserJoinedContent {
-				public string DisplayName { get; set; }
-				public string Id { get; set; }
-			}
+            public class UserJoinedContent
+            {
+                public string DisplayName { get; set; }
+                public string Id { get; set; }
+            }
 
-		}
+        }
 
-		private readonly GraphQLRequest SubscriptionRequest2 = new GraphQLRequest(SubscriptionQuery2);
-
-
-		[Fact]
-		public async void CanConnectTwoSubscriptionsSimultaneously() {
-			var port = NetworkHelpers.GetFreeTcpPortNumber();
-			var callbackTester = new CallbackMonitor<Exception>();
-			var callbackTester2 = new CallbackMonitor<Exception>();
-
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-			await ChatClient.InitializeWebsocketConnection();
-			callbackMonitor.Should().HaveBeenInvokedWithPayload();
-
-			Debug.WriteLine("creating subscription stream");
-			var observable1 = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, callbackTester.Invoke);
-			var observable2 = ChatClient.CreateSubscriptionStream<UserJoinedSubscriptionResult>(SubscriptionRequest2, callbackTester2.Invoke);
-
-			Debug.WriteLine("subscribing...");
-			var messagesMonitor = observable1.Monitor();
-			var joinedMonitor = observable2.Monitor();
-
-			messagesMonitor.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
-
-			const string message1 = "Hello World";
-			var response = await ChatClient.AddMessageAsync(message1);
-			response.Data.AddMessage.Content.Should().Be(message1);
-			messagesMonitor.Should().HaveReceivedPayload()
-				.Which.Data.MessageAdded.Content.Should().Be(message1);
-			joinedMonitor.Should().NotHaveReceivedPayload();
-			
-			var joinResponse = await ChatClient.JoinDeveloperUser();
-			joinResponse.Data.Join.DisplayName.Should().Be("developer", "because that's the display name of user \"1\"");
-
-			var payload = joinedMonitor.Should().HaveReceivedPayload().Subject;
-			payload.Data.UserJoined.Id.Should().Be("1", "because that's the id we sent with our mutation request");
-			payload.Data.UserJoined.DisplayName.Should().Be("developer", "because that's the display name of user \"1\"");
-			messagesMonitor.Should().NotHaveReceivedPayload();
-
-			Debug.WriteLine("disposing subscription...");
-			joinedMonitor.Dispose();
-
-			const string message3 = "lorem ipsum dolor si amet";
-			response = await ChatClient.AddMessageAsync(message3);
-			response.Data.AddMessage.Content.Should().Be(message3);
-			messagesMonitor.Should().HaveReceivedPayload()
-				.Which.Data.MessageAdded.Content.Should().Be(message3);
-
-			// disposing the client should complete the subscription
-			ChatClient.Dispose();
-			messagesMonitor.Should().HaveCompleted();
-		}
+        private readonly GraphQLRequest SubscriptionRequest2 = new GraphQLRequest(SubscriptionQuery2);
 
 
-		[Fact]
-		public async void CanHandleConnectionTimeout() {
-			var errorMonitor = new CallbackMonitor<Exception>();
-			var reconnectBlocker = new ManualResetEventSlim(false);
+        [Fact]
+        public async void CanConnectTwoSubscriptionsSimultaneously()
+        {
+            var port = NetworkHelpers.GetFreeTcpPortNumber();
+            var callbackTester = new CallbackMonitor<Exception>();
+            var callbackTester2 = new CallbackMonitor<Exception>();
 
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-			// configure back-off strategy to allow it to be controlled from within the unit test
-			ChatClient.Options.BackOffStrategy = i => {
-				Debug.WriteLine("back-off strategy: waiting on reconnect blocker");
-				reconnectBlocker.Wait();
-				Debug.WriteLine("back-off strategy: reconnecting...");
-				return TimeSpan.Zero;
-			};
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            await ChatClient.InitializeWebsocketConnection();
+            callbackMonitor.Should().HaveBeenInvokedWithPayload();
 
-			var websocketStates = new ConcurrentQueue<GraphQLWebsocketConnectionState>();
+            Debug.WriteLine("creating subscription stream");
+            var observable1 = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, callbackTester.Invoke);
+            var observable2 = ChatClient.CreateSubscriptionStream<UserJoinedSubscriptionResult>(SubscriptionRequest2, callbackTester2.Invoke);
 
-			using (ChatClient.WebsocketConnectionState.Subscribe(websocketStates.Enqueue)) {
-				websocketStates.Should().ContainSingle(state => state == GraphQLWebsocketConnectionState.Disconnected);
+            Debug.WriteLine("subscribing...");
+            var messagesMonitor = observable1.Monitor();
+            var joinedMonitor = observable2.Monitor();
 
-				Debug.WriteLine($"Test method thread id: {Thread.CurrentThread.ManagedThreadId}");
-				Debug.WriteLine("creating subscription stream");
-				var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, errorMonitor.Invoke);
+            messagesMonitor.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
 
-				Debug.WriteLine("subscribing...");
-				var tester = observable.Monitor();
-				callbackMonitor.Should().HaveBeenInvokedWithPayload();
+            const string message1 = "Hello World";
+            var response = await ChatClient.AddMessageAsync(message1);
+            response.Data.AddMessage.Content.Should().Be(message1);
+            messagesMonitor.Should().HaveReceivedPayload()
+                .Which.Data.MessageAdded.Content.Should().Be(message1);
+            joinedMonitor.Should().NotHaveReceivedPayload();
 
-				websocketStates.Should().ContainInOrder(
-					GraphQLWebsocketConnectionState.Disconnected,
-					GraphQLWebsocketConnectionState.Connecting,
-					GraphQLWebsocketConnectionState.Connected);
-				// clear the collection so the next tests on the collection work as expected
-				websocketStates.Clear();
+            var joinResponse = await ChatClient.JoinDeveloperUser();
+            joinResponse.Data.Join.DisplayName.Should().Be("developer", "because that's the display name of user \"1\"");
 
-				tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+            var payload = joinedMonitor.Should().HaveReceivedPayload().Subject;
+            payload.Data.UserJoined.Id.Should().Be("1", "because that's the id we sent with our mutation request");
+            payload.Data.UserJoined.DisplayName.Should().Be("developer", "because that's the display name of user \"1\"");
+            messagesMonitor.Should().NotHaveReceivedPayload();
 
-				const string message1 = "Hello World";
-				var response = await ChatClient.AddMessageAsync(message1);
-				response.Data.AddMessage.Content.Should().Be(message1);
-				tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
+            Debug.WriteLine("disposing subscription...");
+            joinedMonitor.Dispose();
 
-				Debug.WriteLine("stopping web host...");
-				await Fixture.ShutdownServer();
-				Debug.WriteLine("web host stopped");
+            const string message3 = "lorem ipsum dolor si amet";
+            response = await ChatClient.AddMessageAsync(message3);
+            response.Data.AddMessage.Content.Should().Be(message3);
+            messagesMonitor.Should().HaveReceivedPayload()
+                .Which.Data.MessageAdded.Content.Should().Be(message3);
 
-				errorMonitor.Should().HaveBeenInvokedWithPayload(10.Seconds())
-					.Which.Should().BeOfType<WebSocketException>();
-				websocketStates.Should().Contain(GraphQLWebsocketConnectionState.Disconnected);
-
-				Debug.WriteLine("restarting web host...");
-				await InitializeAsync();
-				Debug.WriteLine("web host started");
-				reconnectBlocker.Set();
-				callbackMonitor.Should().HaveBeenInvokedWithPayload(3.Seconds());
-				tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
-
-				websocketStates.Should().ContainInOrder(
-					GraphQLWebsocketConnectionState.Disconnected,
-					GraphQLWebsocketConnectionState.Connecting,
-					GraphQLWebsocketConnectionState.Connected);
-
-				// disposing the client should complete the subscription
-				ChatClient.Dispose();
-				tester.Should().HaveCompleted(5.Seconds());
-			}
-		}
+            // disposing the client should complete the subscription
+            ChatClient.Dispose();
+            messagesMonitor.Should().HaveCompleted();
+        }
 
 
-		[Fact]
-		public async void CanHandleSubscriptionError() {
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-			await ChatClient.InitializeWebsocketConnection();
-			callbackMonitor.Should().HaveBeenInvokedWithPayload();
-			Debug.WriteLine("creating subscription stream");
-			IObservable<GraphQLResponse<object>> observable = ChatClient.CreateSubscriptionStream<object>(
-				new GraphQLRequest(@"
+        [Fact]
+        public async void CanHandleConnectionTimeout()
+        {
+            var errorMonitor = new CallbackMonitor<Exception>();
+            var reconnectBlocker = new ManualResetEventSlim(false);
+
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            // configure back-off strategy to allow it to be controlled from within the unit test
+            ChatClient.Options.BackOffStrategy = i =>
+            {
+                Debug.WriteLine("back-off strategy: waiting on reconnect blocker");
+                reconnectBlocker.Wait();
+                Debug.WriteLine("back-off strategy: reconnecting...");
+                return TimeSpan.Zero;
+            };
+
+            var websocketStates = new ConcurrentQueue<GraphQLWebsocketConnectionState>();
+
+            using (ChatClient.WebsocketConnectionState.Subscribe(websocketStates.Enqueue))
+            {
+                websocketStates.Should().ContainSingle(state => state == GraphQLWebsocketConnectionState.Disconnected);
+
+                Debug.WriteLine($"Test method thread id: {Thread.CurrentThread.ManagedThreadId}");
+                Debug.WriteLine("creating subscription stream");
+                var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, errorMonitor.Invoke);
+
+                Debug.WriteLine("subscribing...");
+                var tester = observable.Monitor();
+                callbackMonitor.Should().HaveBeenInvokedWithPayload();
+
+                websocketStates.Should().ContainInOrder(
+                    GraphQLWebsocketConnectionState.Disconnected,
+                    GraphQLWebsocketConnectionState.Connecting,
+                    GraphQLWebsocketConnectionState.Connected);
+                // clear the collection so the next tests on the collection work as expected
+                websocketStates.Clear();
+
+                tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+
+                const string message1 = "Hello World";
+                var response = await ChatClient.AddMessageAsync(message1);
+                response.Data.AddMessage.Content.Should().Be(message1);
+                tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(message1);
+
+                Debug.WriteLine("stopping web host...");
+                await Fixture.ShutdownServer();
+                Debug.WriteLine("web host stopped");
+
+                errorMonitor.Should().HaveBeenInvokedWithPayload(10.Seconds())
+                    .Which.Should().BeOfType<WebSocketException>();
+                websocketStates.Should().Contain(GraphQLWebsocketConnectionState.Disconnected);
+
+                Debug.WriteLine("restarting web host...");
+                await InitializeAsync();
+                Debug.WriteLine("web host started");
+                reconnectBlocker.Set();
+                callbackMonitor.Should().HaveBeenInvokedWithPayload(3.Seconds());
+                tester.Should().HaveReceivedPayload().Which.Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+
+                websocketStates.Should().ContainInOrder(
+                    GraphQLWebsocketConnectionState.Disconnected,
+                    GraphQLWebsocketConnectionState.Connecting,
+                    GraphQLWebsocketConnectionState.Connected);
+
+                // disposing the client should complete the subscription
+                ChatClient.Dispose();
+                tester.Should().HaveCompleted(5.Seconds());
+            }
+        }
+
+
+        [Fact]
+        public async void CanHandleSubscriptionError()
+        {
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            await ChatClient.InitializeWebsocketConnection();
+            callbackMonitor.Should().HaveBeenInvokedWithPayload();
+            Debug.WriteLine("creating subscription stream");
+            IObservable<GraphQLResponse<object>> observable = ChatClient.CreateSubscriptionStream<object>(
+                new GraphQLRequest(@"
 					subscription {
 					  failImmediately {
 					    content
 					  }
 					}")
-				);
+                );
 
-			Debug.WriteLine("subscribing...");
-			using (var tester = observable.Monitor()) {
-				tester.Should().HaveReceivedPayload(TimeSpan.FromSeconds(3))
-					.Which.Errors.Should().ContainSingle();
-				tester.Should().HaveCompleted();
-				ChatClient.Dispose();
-			}
-			
-		}
+            Debug.WriteLine("subscribing...");
+            using (var tester = observable.Monitor())
+            {
+                tester.Should().HaveReceivedPayload(TimeSpan.FromSeconds(3))
+                    .Which.Errors.Should().ContainSingle();
+                tester.Should().HaveCompleted();
+                ChatClient.Dispose();
+            }
+
+        }
 
 
-		[Fact]
-		public async void CanHandleQueryErrorInSubscription() {
-			var test = new GraphQLRequest("tset", new { test = "blaa" });
+        [Fact]
+        public async void CanHandleQueryErrorInSubscription()
+        {
+            var test = new GraphQLRequest("tset", new { test = "blaa" });
 
-			var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-			await ChatClient.InitializeWebsocketConnection();
-			callbackMonitor.Should().HaveBeenInvokedWithPayload();
-			Debug.WriteLine("creating subscription stream");
-			IObservable<GraphQLResponse<object>> observable = ChatClient.CreateSubscriptionStream<object>(
-				new GraphQLRequest(@"
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            await ChatClient.InitializeWebsocketConnection();
+            callbackMonitor.Should().HaveBeenInvokedWithPayload();
+            Debug.WriteLine("creating subscription stream");
+            IObservable<GraphQLResponse<object>> observable = ChatClient.CreateSubscriptionStream<object>(
+                new GraphQLRequest(@"
 					subscription {
 					  fieldDoesNotExist {
 					    content
 					  }
 					}")
-			);
+            );
 
-			Debug.WriteLine("subscribing...");
-			using (var tester = observable.Monitor()) {
-				tester.Should().HaveReceivedPayload()
-					.Which.Errors.Should().ContainSingle();
-				tester.Should().HaveCompleted();
-				ChatClient.Dispose();
-			}
-		}
+            Debug.WriteLine("subscribing...");
+            using (var tester = observable.Monitor())
+            {
+                tester.Should().HaveReceivedPayload()
+                    .Which.Errors.Should().ContainSingle();
+                tester.Should().HaveCompleted();
+                ChatClient.Dispose();
+            }
+        }
 
-	}
+    }
 }

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
@@ -27,8 +27,8 @@ namespace GraphQL.Integration.Tests.WebsocketTests
 
         protected Base(ITestOutputHelper output, IntegrationServerTestFixture fixture)
         {
-            this.Output = output;
-            this.Fixture = fixture;
+            Output = output;
+            Fixture = fixture;
         }
 
         protected static ReceivedMessage InitialMessage = new ReceivedMessage
@@ -113,14 +113,14 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             response.Errors.Should().ContainSingle("because the query is invalid");
         }
 
-        private const string SubscriptionQuery = @"
+        private const string SUBSCRIPTION_QUERY = @"
 			subscription {
 			  messageAdded{
 			    content
 			  }
 			}";
 
-        private readonly GraphQLRequest SubscriptionRequest = new GraphQLRequest(SubscriptionQuery);
+        private readonly GraphQLRequest _subscriptionRequest = new GraphQLRequest(SUBSCRIPTION_QUERY);
 
 
         [Fact]
@@ -131,7 +131,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             callbackMonitor.Should().HaveBeenInvokedWithPayload();
 
             Debug.WriteLine("creating subscription stream");
-            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
+            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest);
 
             Debug.WriteLine("subscribing...");
             using var tester = observable.Monitor();
@@ -169,7 +169,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
 
             Debug.WriteLine("creating subscription stream");
-            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest);
+            var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest);
 
             Debug.WriteLine("subscribing...");
             var tester = observable.Monitor();
@@ -208,7 +208,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             tester2.Dispose();
         }
 
-        private const string SubscriptionQuery2 = @"
+        private const string SUBSCRIPTION_QUERY2 = @"
 			subscription {
 			  userJoined{
 				displayName
@@ -228,7 +228,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
 
         }
 
-        private readonly GraphQLRequest SubscriptionRequest2 = new GraphQLRequest(SubscriptionQuery2);
+        private readonly GraphQLRequest _subscriptionRequest2 = new GraphQLRequest(SUBSCRIPTION_QUERY2);
 
 
         [Fact]
@@ -243,8 +243,8 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             callbackMonitor.Should().HaveBeenInvokedWithPayload();
 
             Debug.WriteLine("creating subscription stream");
-            var observable1 = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, callbackTester.Invoke);
-            var observable2 = ChatClient.CreateSubscriptionStream<UserJoinedSubscriptionResult>(SubscriptionRequest2, callbackTester2.Invoke);
+            var observable1 = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest, callbackTester.Invoke);
+            var observable2 = ChatClient.CreateSubscriptionStream<UserJoinedSubscriptionResult>(_subscriptionRequest2, callbackTester2.Invoke);
 
             Debug.WriteLine("subscribing...");
             var messagesMonitor = observable1.Monitor();
@@ -306,7 +306,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
 
                 Debug.WriteLine($"Test method thread id: {Thread.CurrentThread.ManagedThreadId}");
                 Debug.WriteLine("creating subscription stream");
-                var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(SubscriptionRequest, errorMonitor.Invoke);
+                var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest, errorMonitor.Invoke);
 
                 Debug.WriteLine("subscribing...");
                 var tester = observable.Monitor();

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
@@ -1,4 +1,3 @@
-using GraphQL.Client.Serializer.Newtonsoft;
 using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
@@ -3,9 +3,11 @@ using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace GraphQL.Integration.Tests.WebsocketTests {
-	public class Newtonsoft: Base, IClassFixture<NewtonsoftIntegrationServerTestFixture> {
-		public Newtonsoft(ITestOutputHelper output, NewtonsoftIntegrationServerTestFixture fixture) : base(output, fixture)
-		{ }
-	}
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public class Newtonsoft : Base, IClassFixture<NewtonsoftIntegrationServerTestFixture>
+    {
+        public Newtonsoft(ITestOutputHelper output, NewtonsoftIntegrationServerTestFixture fixture) : base(output, fixture)
+        { }
+    }
 }

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/SystemTextJson.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/SystemTextJson.cs
@@ -2,10 +2,12 @@ using GraphQL.Integration.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace GraphQL.Integration.Tests.WebsocketTests {
-	public class SystemTextJson: Base, IClassFixture<SystemTextJsonIntegrationServerTestFixture> {
-		public SystemTextJson(ITestOutputHelper output, SystemTextJsonIntegrationServerTestFixture fixture) : base(output, fixture)
-		{
-		}
-	}
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public class SystemTextJson : Base, IClassFixture<SystemTextJsonIntegrationServerTestFixture>
+    {
+        public SystemTextJson(ITestOutputHelper output, SystemTextJsonIntegrationServerTestFixture fixture) : base(output, fixture)
+        {
+        }
+    }
 }

--- a/tests/GraphQL.Primitives.Tests/GraphQLLocationTest.cs
+++ b/tests/GraphQL.Primitives.Tests/GraphQLLocationTest.cs
@@ -1,57 +1,66 @@
 using Xunit;
 
-namespace GraphQL.Primitives.Tests {
+namespace GraphQL.Primitives.Tests
+{
 
-	public class GraphQLLocationTest {
+    public class GraphQLLocationTest
+    {
 
-		[Fact]
-		public void ConstructorFact() {
-			var graphQLLocation = new GraphQLLocation { Column = 1, Line = 2 };
-			Assert.Equal(1U, graphQLLocation.Column);
-			Assert.Equal(2U, graphQLLocation.Line);
-		}
+        [Fact]
+        public void ConstructorFact()
+        {
+            var graphQLLocation = new GraphQLLocation { Column = 1, Line = 2 };
+            Assert.Equal(1U, graphQLLocation.Column);
+            Assert.Equal(2U, graphQLLocation.Line);
+        }
 
-		[Fact]
-		public void Equality1Fact() {
-			var graphQLLocation = new GraphQLLocation { Column = 1, Line = 2 };
-			Assert.Equal(graphQLLocation, graphQLLocation);
-		}
+        [Fact]
+        public void Equality1Fact()
+        {
+            var graphQLLocation = new GraphQLLocation { Column = 1, Line = 2 };
+            Assert.Equal(graphQLLocation, graphQLLocation);
+        }
 
-		[Fact]
-		public void Equality2Fact() {
-			var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
-			var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
-			Assert.Equal(graphQLLocation1, graphQLLocation2);
-		}
+        [Fact]
+        public void Equality2Fact()
+        {
+            var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
+            var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
+            Assert.Equal(graphQLLocation1, graphQLLocation2);
+        }
 
-		[Fact]
-		public void EqualityOperatorFact() {
-			var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
-			var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
-			Assert.True(graphQLLocation1 == graphQLLocation2);
-		}
+        [Fact]
+        public void EqualityOperatorFact()
+        {
+            var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
+            var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
+            Assert.True(graphQLLocation1 == graphQLLocation2);
+        }
 
-		[Fact]
-		public void InEqualityFact() {
-			var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
-			var graphQLLocation2 = new GraphQLLocation { Column = 2, Line = 1 };
-			Assert.NotEqual(graphQLLocation1, graphQLLocation2);
-		}
+        [Fact]
+        public void InEqualityFact()
+        {
+            var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
+            var graphQLLocation2 = new GraphQLLocation { Column = 2, Line = 1 };
+            Assert.NotEqual(graphQLLocation1, graphQLLocation2);
+        }
 
-		[Fact]
-		public void InEqualityOperatorFact() {
-			var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
-			var graphQLLocation2 = new GraphQLLocation { Column = 2, Line = 1 };
-			Assert.True(graphQLLocation1 != graphQLLocation2);
-		}
+        [Fact]
+        public void InEqualityOperatorFact()
+        {
+            var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
+            var graphQLLocation2 = new GraphQLLocation { Column = 2, Line = 1 };
+            Assert.True(graphQLLocation1 != graphQLLocation2);
+        }
 
-		[Fact]
-		public void GetHashCodeFact() {
-			var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
-			var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
-			Assert.True(graphQLLocation1.GetHashCode() == graphQLLocation2.GetHashCode());
-		}
+        [Fact]
+        public void GetHashCodeFact()
+        {
+            var graphQLLocation1 = new GraphQLLocation { Column = 1, Line = 2 };
+            var graphQLLocation2 = new GraphQLLocation { Column = 1, Line = 2 };
+            Assert.True(graphQLLocation1.GetHashCode() == graphQLLocation2.GetHashCode());
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Primitives.Tests/GraphQLRequestTest.cs
+++ b/tests/GraphQL.Primitives.Tests/GraphQLRequestTest.cs
@@ -1,157 +1,182 @@
 using Xunit;
 
-namespace GraphQL.Primitives.Tests {
+namespace GraphQL.Primitives.Tests
+{
 
-	public class GraphQLRequestTest {
+    public class GraphQLRequestTest
+    {
 
-		[Fact]
-		public void ConstructorFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}");
-			Assert.NotNull(graphQLRequest.Query);
-			Assert.Null(graphQLRequest.OperationName);
-			Assert.Null(graphQLRequest.Variables);
-		}
+        [Fact]
+        public void ConstructorFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}");
+            Assert.NotNull(graphQLRequest.Query);
+            Assert.Null(graphQLRequest.OperationName);
+            Assert.Null(graphQLRequest.Variables);
+        }
 
-		[Fact]
-		public void ConstructorExtendedFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.NotNull(graphQLRequest.Query);
-			Assert.NotNull(graphQLRequest.OperationName);
-			Assert.NotNull(graphQLRequest.Variables);
-		}
+        [Fact]
+        public void ConstructorExtendedFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.NotNull(graphQLRequest.Query);
+            Assert.NotNull(graphQLRequest.OperationName);
+            Assert.NotNull(graphQLRequest.Variables);
+        }
 
-		[Fact]
-		public void Equality1Fact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}");
-			Assert.Equal(graphQLRequest, graphQLRequest);
-		}
+        [Fact]
+        public void Equality1Fact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}");
+            Assert.Equal(graphQLRequest, graphQLRequest);
+        }
 
-		[Fact]
-		public void Equality2Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}");
-			Assert.Equal(graphQLRequest1, graphQLRequest2);
-		}
+        [Fact]
+        public void Equality2Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}");
+            Assert.Equal(graphQLRequest1, graphQLRequest2);
+        }
 
-		[Fact]
-		public void Equality3Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.Equal(graphQLRequest1, graphQLRequest2);
-		}
+        [Fact]
+        public void Equality3Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.Equal(graphQLRequest1, graphQLRequest2);
+        }
 
 
-		[Fact]
-		public void Equality4Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
-			Assert.NotEqual(graphQLRequest1, graphQLRequest2);
-		}
+        [Fact]
+        public void Equality4Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
+            Assert.NotEqual(graphQLRequest1, graphQLRequest2);
+        }
 
-		[Fact]
-		public void EqualityOperatorFact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.True(graphQLRequest1 == graphQLRequest2);
-		}
+        [Fact]
+        public void EqualityOperatorFact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.True(graphQLRequest1 == graphQLRequest2);
+        }
 
-		[Fact]
-		public void InEquality1Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name1}}");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name2}}");
-			Assert.NotEqual(graphQLRequest1, graphQLRequest2);
-		}
+        [Fact]
+        public void InEquality1Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name1}}");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name2}}");
+            Assert.NotEqual(graphQLRequest1, graphQLRequest2);
+        }
 
-		[Fact]
-		public void InEquality2Fact() {
-			GraphQLRequest graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
-			GraphQLRequest graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
-			Assert.NotEqual(graphQLRequest1, graphQLRequest2);
-		}
+        [Fact]
+        public void InEquality2Fact()
+        {
+            GraphQLRequest graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
+            GraphQLRequest graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
+            Assert.NotEqual(graphQLRequest1, graphQLRequest2);
+        }
 
-		[Fact]
-		public void InEqualityOperatorFact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name1}}");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name2}}");
-			Assert.True(graphQLRequest1 != graphQLRequest2);
-		}
+        [Fact]
+        public void InEqualityOperatorFact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name1}}");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name2}}");
+            Assert.True(graphQLRequest1 != graphQLRequest2);
+        }
 
-		[Fact]
-		public void GetHashCode1Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}");
-			Assert.True(graphQLRequest1.GetHashCode() == graphQLRequest2.GetHashCode());
-		}
+        [Fact]
+        public void GetHashCode1Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}");
+            Assert.True(graphQLRequest1.GetHashCode() == graphQLRequest2.GetHashCode());
+        }
 
-		[Fact]
-		public void GetHashCode2Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.True(graphQLRequest1.GetHashCode() == graphQLRequest2.GetHashCode());
-		}
+        [Fact]
+        public void GetHashCode2Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.True(graphQLRequest1.GetHashCode() == graphQLRequest2.GetHashCode());
+        }
 
-		[Fact]
-		public void GetHashCode3Fact() {
-			var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
-			var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
-			Assert.True(graphQLRequest1.GetHashCode() != graphQLRequest2.GetHashCode());
-		}
+        [Fact]
+        public void GetHashCode3Fact()
+        {
+            var graphQLRequest1 = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
+            var graphQLRequest2 = new GraphQLRequest("{hero{name}}", new { varName = "varValue2" }, "operationName");
+            Assert.True(graphQLRequest1.GetHashCode() != graphQLRequest2.GetHashCode());
+        }
 
-		[Fact]
-		public void PropertyQueryGetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
-			Assert.Equal("{hero{name}}", graphQLRequest.Query);
-		}
+        [Fact]
+        public void PropertyQueryGetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
+            Assert.Equal("{hero{name}}", graphQLRequest.Query);
+        }
 
-		[Fact]
-		public void PropertyQuerySetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
-			graphQLRequest.Query = "{hero{name2}}";
-			Assert.Equal("{hero{name2}}", graphQLRequest.Query);
-		}
+        [Fact]
+        public void PropertyQuerySetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName");
+            graphQLRequest.Query = "{hero{name2}}";
+            Assert.Equal("{hero{name2}}", graphQLRequest.Query);
+        }
 
-		[Fact]
-		public void PropertyOperationNameGetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.Equal("operationName", graphQLRequest.OperationName);
-		}
+        [Fact]
+        public void PropertyOperationNameGetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.Equal("operationName", graphQLRequest.OperationName);
+        }
 
-		[Fact]
-		public void PropertyOperationNameNullGetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}");
-			Assert.Null(graphQLRequest.OperationName);
-		}
+        [Fact]
+        public void PropertyOperationNameNullGetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}");
+            Assert.Null(graphQLRequest.OperationName);
+        }
 
-		[Fact]
-		public void PropertyOperationNameSetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName1");
-			graphQLRequest.OperationName = "operationName2";
-			Assert.Equal("operationName2", graphQLRequest.OperationName);
-		}
+        [Fact]
+        public void PropertyOperationNameSetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName1");
+            graphQLRequest.OperationName = "operationName2";
+            Assert.Equal("operationName2", graphQLRequest.OperationName);
+        }
 
-		[Fact]
-		public void PropertyVariableGetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
-			Assert.Equal(new { varName = "varValue" }, graphQLRequest.Variables);
-		}
+        [Fact]
+        public void PropertyVariableGetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue" }, "operationName");
+            Assert.Equal(new { varName = "varValue" }, graphQLRequest.Variables);
+        }
 
-		[Fact]
-		public void PropertyVariableNullGetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}");
-			Assert.Null(graphQLRequest.Variables);
-		}
+        [Fact]
+        public void PropertyVariableNullGetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}");
+            Assert.Null(graphQLRequest.Variables);
+        }
 
-		[Fact]
-		public void PropertyVariableSetFact() {
-			var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName1");
-			graphQLRequest.Variables = new {
-				varName = "varValue2"
-			};
-			Assert.Equal(new {
-				varName = "varValue2"
-			}, graphQLRequest.Variables);
-		}
+        [Fact]
+        public void PropertyVariableSetFact()
+        {
+            var graphQLRequest = new GraphQLRequest("{hero{name}}", new { varName = "varValue1" }, "operationName1");
+            graphQLRequest.Variables = new
+            {
+                varName = "varValue2"
+            };
+            Assert.Equal(new
+            {
+                varName = "varValue2"
+            }, graphQLRequest.Variables);
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Primitives.Tests/GraphQLResponseTest.cs
+++ b/tests/GraphQL.Primitives.Tests/GraphQLResponseTest.cs
@@ -1,98 +1,118 @@
 using Xunit;
 
-namespace GraphQL.Primitives.Tests {
+namespace GraphQL.Primitives.Tests
+{
 
-	public class GraphQLResponseTest {
+    public class GraphQLResponseTest
+    {
 
-		[Fact]
-		public void Constructor1Fact() {
-			var graphQLResponse = new GraphQLResponse<object>();
-			Assert.Null(graphQLResponse.Data);
-			Assert.Null(graphQLResponse.Errors);
-		}
+        [Fact]
+        public void Constructor1Fact()
+        {
+            var graphQLResponse = new GraphQLResponse<object>();
+            Assert.Null(graphQLResponse.Data);
+            Assert.Null(graphQLResponse.Errors);
+        }
 
-		[Fact]
-		public void Constructor2Fact() {
-			var graphQLResponse = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			Assert.NotNull(graphQLResponse.Data);
-			Assert.NotNull(graphQLResponse.Errors);
-		}
+        [Fact]
+        public void Constructor2Fact()
+        {
+            var graphQLResponse = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            Assert.NotNull(graphQLResponse.Data);
+            Assert.NotNull(graphQLResponse.Errors);
+        }
 
-		[Fact]
-		public void Equality1Fact() {
-			var graphQLResponse = new GraphQLResponse<object>();
-			Assert.Equal(graphQLResponse, graphQLResponse);
-		}
+        [Fact]
+        public void Equality1Fact()
+        {
+            var graphQLResponse = new GraphQLResponse<object>();
+            Assert.Equal(graphQLResponse, graphQLResponse);
+        }
 
-		[Fact]
-		public void Equality2Fact() {
-			var graphQLResponse1 = new GraphQLResponse<object>();
-			var graphQLResponse2 = new GraphQLResponse<object>();
-			Assert.Equal(graphQLResponse1, graphQLResponse2);
-		}
+        [Fact]
+        public void Equality2Fact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>();
+            var graphQLResponse2 = new GraphQLResponse<object>();
+            Assert.Equal(graphQLResponse1, graphQLResponse2);
+        }
 
-		[Fact]
-		public void Equality3Fact() {
-			var graphQLResponse1 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			var graphQLResponse2 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			Assert.Equal(graphQLResponse1, graphQLResponse2);
-		}
+        [Fact]
+        public void Equality3Fact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            var graphQLResponse2 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            Assert.Equal(graphQLResponse1, graphQLResponse2);
+        }
 
-		[Fact]
-		public void EqualityOperatorFact() {
-			var graphQLResponse1 = new GraphQLResponse<object>();
-			var graphQLResponse2 = new GraphQLResponse<object>();
-			Assert.True(graphQLResponse1 == graphQLResponse2);
-		}
+        [Fact]
+        public void EqualityOperatorFact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>();
+            var graphQLResponse2 = new GraphQLResponse<object>();
+            Assert.True(graphQLResponse1 == graphQLResponse2);
+        }
 
-		[Fact]
-		public void InEqualityFact() {
-			var graphQLResponse1 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			var graphQLResponse2 = new GraphQLResponse<object> {
-				Data = new { a = 2 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			Assert.NotEqual(graphQLResponse1, graphQLResponse2);
-		}
+        [Fact]
+        public void InEqualityFact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            var graphQLResponse2 = new GraphQLResponse<object>
+            {
+                Data = new { a = 2 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            Assert.NotEqual(graphQLResponse1, graphQLResponse2);
+        }
 
-		[Fact]
-		public void InEqualityOperatorFact() {
-			var graphQLResponse1 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			var graphQLResponse2 = new GraphQLResponse<object> {
-				Data = new { a = 2 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			Assert.True(graphQLResponse1 != graphQLResponse2);
-		}
+        [Fact]
+        public void InEqualityOperatorFact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            var graphQLResponse2 = new GraphQLResponse<object>
+            {
+                Data = new { a = 2 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            Assert.True(graphQLResponse1 != graphQLResponse2);
+        }
 
-		[Fact]
-		public void GetHashCodeFact() {
-			var graphQLResponse1 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			var graphQLResponse2 = new GraphQLResponse<object> {
-				Data = new { a = 1 },
-				Errors = new[] { new GraphQLError { Message = "message" } }
-			};
-			Assert.True(graphQLResponse1.GetHashCode() == graphQLResponse2.GetHashCode());
-		}
+        [Fact]
+        public void GetHashCodeFact()
+        {
+            var graphQLResponse1 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            var graphQLResponse2 = new GraphQLResponse<object>
+            {
+                Data = new { a = 1 },
+                Errors = new[] { new GraphQLError { Message = "message" } }
+            };
+            Assert.True(graphQLResponse1.GetHashCode() == graphQLResponse2.GetHashCode());
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Primitives.Tests/JsonSerializationTests.cs
+++ b/tests/GraphQL.Primitives.Tests/JsonSerializationTests.cs
@@ -3,28 +3,33 @@ using System.Text.Json;
 using FluentAssertions;
 using Xunit;
 
-namespace GraphQL.Primitives.Tests {
-	public class JsonSerializationTests {
+namespace GraphQL.Primitives.Tests
+{
+    public class JsonSerializationTests
+    {
 
-		[Fact]
-		public void WebSocketResponseDeserialization() {
-			var testObject = new ExtendedTestObject { Id = "test", OtherData = "this is some other stuff" };
-			var json = JsonSerializer.Serialize(testObject);
-			var deserialized = JsonSerializer.Deserialize<TestObject>(json);
-			var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-			var childObject = (JsonElement) dict["ChildObject"];
-			childObject.GetProperty("Id").GetString().Should().Be(testObject.ChildObject.Id);
-		}
+        [Fact]
+        public void WebSocketResponseDeserialization()
+        {
+            var testObject = new ExtendedTestObject { Id = "test", OtherData = "this is some other stuff" };
+            var json = JsonSerializer.Serialize(testObject);
+            var deserialized = JsonSerializer.Deserialize<TestObject>(json);
+            var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            var childObject = (JsonElement)dict["ChildObject"];
+            childObject.GetProperty("Id").GetString().Should().Be(testObject.ChildObject.Id);
+        }
 
-		public class TestObject {
-			public string Id { get; set; }
+        public class TestObject
+        {
+            public string Id { get; set; }
 
-		}
+        }
 
-		public class ExtendedTestObject : TestObject {
-			public string OtherData { get; set; }
+        public class ExtendedTestObject : TestObject
+        {
+            public string OtherData { get; set; }
 
-			public TestObject ChildObject{ get; set; } = new TestObject {Id = "1337"};
-		}
-	}
+            public TestObject ChildObject { get; set; } = new TestObject { Id = "1337" };
+        }
+    }
 }

--- a/tests/GraphQL.Server.Test/GraphQL/Models/Repository.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/Models/Repository.cs
@@ -18,12 +18,12 @@ namespace GraphQL.Server.Test.GraphQL.Models
 
         public RepositoryGraphType()
         {
-            this.Name = nameof(Repository);
-            this.Field(expression => expression.DatabaseId);
-            this.Field<NonNullGraphType<IdGraphType>>("id");
-            this.Field(expression => expression.Name);
+            Name = nameof(Repository);
+            Field(expression => expression.DatabaseId);
+            Field<NonNullGraphType<IdGraphType>>("id");
+            Field(expression => expression.Name);
             //this.Field(expression => expression.Owner);
-            this.Field<NonNullGraphType<UriGraphType>>("url");
+            Field<NonNullGraphType<UriGraphType>>("url");
         }
 
     }

--- a/tests/GraphQL.Server.Test/GraphQL/Models/Repository.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/Models/Repository.cs
@@ -1,27 +1,31 @@
 using System;
 using GraphQL.Types;
 
-namespace GraphQL.Server.Test.GraphQL.Models {
+namespace GraphQL.Server.Test.GraphQL.Models
+{
 
-	public class Repository {
-		public int DatabaseId { get; set; }
-		public string Id { get; set; }
-		public string Name { get; set; }
-		public object Owner { get; set; }
-		public Uri Url { get; set; }
-	}
+    public class Repository
+    {
+        public int DatabaseId { get; set; }
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public object Owner { get; set; }
+        public Uri Url { get; set; }
+    }
 
-	public class RepositoryGraphType : ObjectGraphType<Repository> {
+    public class RepositoryGraphType : ObjectGraphType<Repository>
+    {
 
-		public RepositoryGraphType() {
-			this.Name = nameof(Repository);
-			this.Field(expression => expression.DatabaseId);
-			this.Field<NonNullGraphType<IdGraphType>>("id");
-			this.Field(expression => expression.Name);
-			//this.Field(expression => expression.Owner);
-			this.Field<NonNullGraphType<UriGraphType>>("url");
-		}
+        public RepositoryGraphType()
+        {
+            this.Name = nameof(Repository);
+            this.Field(expression => expression.DatabaseId);
+            this.Field<NonNullGraphType<IdGraphType>>("id");
+            this.Field(expression => expression.Name);
+            //this.Field(expression => expression.Owner);
+            this.Field<NonNullGraphType<UriGraphType>>("url");
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/GraphQL/Storage.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/Storage.cs
@@ -3,20 +3,23 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Server.Test.GraphQL.Models;
 
-namespace GraphQL.Server.Test.GraphQL {
+namespace GraphQL.Server.Test.GraphQL
+{
 
-	public static class Storage {
+    public static class Storage
+    {
 
-		public static IQueryable<Repository> Repositories { get; } = new List<Repository>()
-			.Append(new Repository {
-				DatabaseId = 113196300,
-				Id = "MDEwOlJlcG9zaXRvcnkxMTMxOTYzMDA=",
-				Name = "graphql-client",
-				Owner = null,
-				Url = new Uri("https://github.com/graphql-dotnet/graphql-client")
-			})
-			.AsQueryable();
+        public static IQueryable<Repository> Repositories { get; } = new List<Repository>()
+            .Append(new Repository
+            {
+                DatabaseId = 113196300,
+                Id = "MDEwOlJlcG9zaXRvcnkxMTMxOTYzMDA=",
+                Name = "graphql-client",
+                Owner = null,
+                Url = new Uri("https://github.com/graphql-dotnet/graphql-client")
+            })
+            .AsQueryable();
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/GraphQL/TestMutation.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestMutation.cs
@@ -1,12 +1,15 @@
 using GraphQL.Types;
 
-namespace GraphQL.Server.Test.GraphQL {
+namespace GraphQL.Server.Test.GraphQL
+{
 
-	public class TestMutation : ObjectGraphType {
+    public class TestMutation : ObjectGraphType
+    {
 
-		public TestMutation() {
-		}
+        public TestMutation()
+        {
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/GraphQL/TestQuery.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestQuery.cs
@@ -2,18 +2,22 @@ using System.Linq;
 using GraphQL.Server.Test.GraphQL.Models;
 using GraphQL.Types;
 
-namespace GraphQL.Server.Test.GraphQL {
+namespace GraphQL.Server.Test.GraphQL
+{
 
-	public class TestQuery : ObjectGraphType {
+    public class TestQuery : ObjectGraphType
+    {
 
-		public TestQuery() {
-			this.Field<RepositoryGraphType>("repository", arguments: new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "owner" }, new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" }), resolve: context => {
-				var owner = context.GetArgument<string>("owner");
-				var name = context.GetArgument<string>("name");
-				return Storage.Repositories.FirstOrDefault(predicate => predicate.Name == name);
-			});
-		}
+        public TestQuery()
+        {
+            this.Field<RepositoryGraphType>("repository", arguments: new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "owner" }, new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" }), resolve: context =>
+            {
+                var owner = context.GetArgument<string>("owner");
+                var name = context.GetArgument<string>("name");
+                return Storage.Repositories.FirstOrDefault(predicate => predicate.Name == name);
+            });
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/GraphQL/TestQuery.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestQuery.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Server.Test.GraphQL
 
         public TestQuery()
         {
-            this.Field<RepositoryGraphType>("repository", arguments: new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "owner" }, new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" }), resolve: context =>
+            Field<RepositoryGraphType>("repository", arguments: new QueryArguments(new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "owner" }, new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "name" }), resolve: context =>
             {
                 var owner = context.GetArgument<string>("owner");
                 var name = context.GetArgument<string>("name");

--- a/tests/GraphQL.Server.Test/GraphQL/TestSchema.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestSchema.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Test.GraphQL
 
         public TestSchema()
         {
-            this.Query = new TestQuery();
+            Query = new TestQuery();
             //this.Mutation = new TestMutation();
             //this.Subscription = new TestSubscription();
         }

--- a/tests/GraphQL.Server.Test/GraphQL/TestSchema.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestSchema.cs
@@ -1,15 +1,18 @@
 using GraphQL.Types;
 
-namespace GraphQL.Server.Test.GraphQL {
+namespace GraphQL.Server.Test.GraphQL
+{
 
-	public class TestSchema : Schema {
+    public class TestSchema : Schema
+    {
 
-		public TestSchema() {
-			this.Query = new TestQuery();
-			//this.Mutation = new TestMutation();
-			//this.Subscription = new TestSubscription();
-		}
+        public TestSchema()
+        {
+            this.Query = new TestQuery();
+            //this.Mutation = new TestMutation();
+            //this.Subscription = new TestSubscription();
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/GraphQL/TestSubscription.cs
+++ b/tests/GraphQL.Server.Test/GraphQL/TestSubscription.cs
@@ -1,12 +1,15 @@
 using GraphQL.Types;
 
-namespace GraphQL.Server.Test.GraphQL {
+namespace GraphQL.Server.Test.GraphQL
+{
 
-	public class TestSubscription : ObjectGraphType {
+    public class TestSubscription : ObjectGraphType
+    {
 
-		public TestSubscription() {
-		}
+        public TestSubscription()
+        {
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/Program.cs
+++ b/tests/GraphQL.Server.Test/Program.cs
@@ -2,18 +2,20 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
-namespace GraphQL.Server.Test {
+namespace GraphQL.Server.Test
+{
 
-	public class Program {
+    public class Program
+    {
 
-		public static async Task Main(string[] args) =>
-			await CreateHostBuilder(args).Build().RunAsync();
+        public static async Task Main(string[] args) =>
+            await CreateHostBuilder(args).Build().RunAsync();
 
-		public static IWebHostBuilder CreateHostBuilder(string[] args = null) =>
-			WebHost.CreateDefaultBuilder(args)
-				.UseKestrel(options => { options.AllowSynchronousIO = true; })
-				.UseStartup<Startup>();
+        public static IWebHostBuilder CreateHostBuilder(string[] args = null) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(options => { options.AllowSynchronousIO = true; })
+                .UseStartup<Startup>();
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/Startup.cs
+++ b/tests/GraphQL.Server.Test/Startup.cs
@@ -6,37 +6,44 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace GraphQL.Server.Test {
+namespace GraphQL.Server.Test
+{
 
-	public class Startup {
+    public class Startup
+    {
 
-		public IConfiguration Configuration { get; }
+        public IConfiguration Configuration { get; }
 
-		public Startup(IConfiguration configuration) {
-			this.Configuration = configuration;
-		}
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
 
-		public void Configure(IApplicationBuilder app) {
-			var webHostEnvironment = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
-			if (webHostEnvironment.IsDevelopment()) {
-				app.UseDeveloperExceptionPage();
-			}
-			app.UseHttpsRedirection();
+        public void Configure(IApplicationBuilder app)
+        {
+            var webHostEnvironment = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+            if (webHostEnvironment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            app.UseHttpsRedirection();
 
-			app.UseWebSockets();
-			app.UseGraphQLWebSockets<TestSchema>();
-			app.UseGraphQL<TestSchema>();
-			app.UseGraphiQLServer(new GraphiQLOptions { });
-		}
+            app.UseWebSockets();
+            app.UseGraphQLWebSockets<TestSchema>();
+            app.UseGraphQL<TestSchema>();
+            app.UseGraphiQLServer(new GraphiQLOptions { });
+        }
 
-		public void ConfigureServices(IServiceCollection services) {
-			services.AddSingleton<TestSchema>();
-			services.AddGraphQL(options => {
-				options.EnableMetrics = true;
-				options.ExposeExceptions = true;
-			}).AddWebSockets();
-		}
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<TestSchema>();
+            services.AddGraphQL(options =>
+            {
+                options.EnableMetrics = true;
+                options.ExposeExceptions = true;
+            }).AddWebSockets();
+        }
 
-	}
+    }
 
 }

--- a/tests/GraphQL.Server.Test/Startup.cs
+++ b/tests/GraphQL.Server.Test/Startup.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Test
 
         public Startup(IConfiguration configuration)
         {
-            this.Configuration = configuration;
+            Configuration = configuration;
         }
 
         public void Configure(IApplicationBuilder app)

--- a/tests/IntegrationTestServer/Program.cs
+++ b/tests/IntegrationTestServer/Program.cs
@@ -6,10 +6,7 @@ namespace IntegrationTestServer
 {
     public class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+        public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)

--- a/tests/IntegrationTestServer/Program.cs
+++ b/tests/IntegrationTestServer/Program.cs
@@ -2,15 +2,18 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace IntegrationTestServer {
-	public class Program {
-		public static void Main(string[] args) {
-			CreateWebHostBuilder(args).Build().Run();
-		}
+namespace IntegrationTestServer
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
 
-		public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-			WebHost.CreateDefaultBuilder(args)
-				.UseStartup<Startup>()
-				.ConfigureLogging((ctx, logging) => logging.SetMinimumLevel(LogLevel.Debug));
-	}
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .ConfigureLogging((ctx, logging) => logging.SetMinimumLevel(LogLevel.Debug));
+    }
 }

--- a/tests/IntegrationTestServer/Startup.cs
+++ b/tests/IntegrationTestServer/Startup.cs
@@ -13,59 +13,68 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace IntegrationTestServer {
-	public class Startup {
-		public Startup(IConfiguration configuration, IWebHostEnvironment environment) {
-			Configuration = configuration;
-			Environment = environment;
-		}
+namespace IntegrationTestServer
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration, IWebHostEnvironment environment)
+        {
+            Configuration = configuration;
+            Environment = environment;
+        }
 
-		public IConfiguration Configuration { get; }
-		public IWebHostEnvironment Environment { get; }
+        public IConfiguration Configuration { get; }
+        public IWebHostEnvironment Environment { get; }
 
-		// This method gets called by the runtime. Use this method to add services to the container.
-		// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-		public void ConfigureServices(IServiceCollection services) {
-			services.Configure<KestrelServerOptions>(options =>
-			{
-				options.AllowSynchronousIO = true;
-			});
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                options.AllowSynchronousIO = true;
+            });
 
-			services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
-			services.AddChatSchema();
-			services.AddStarWarsSchema();
-			services.AddGraphQL(options => {
-				options.EnableMetrics = true;
-				options.ExposeExceptions = Environment.IsDevelopment();
-			})
-				.AddWebSockets();
-		}
+            services.AddTransient<IDependencyResolver>(provider => new FuncDependencyResolver(provider.GetService));
+            services.AddChatSchema();
+            services.AddStarWarsSchema();
+            services.AddGraphQL(options =>
+            {
+                options.EnableMetrics = true;
+                options.ExposeExceptions = Environment.IsDevelopment();
+            })
+                .AddWebSockets();
+        }
 
-		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
-			if (env.IsDevelopment()) {
-				app.UseDeveloperExceptionPage();
-			}
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
 
-			app.UseWebSockets();
+            app.UseWebSockets();
 
-			ConfigureGraphQLSchema<ChatSchema>(app, Common.ChatEndpoint);
-			ConfigureGraphQLSchema<StarWarsSchema>(app, Common.StarWarsEndpoint);
+            ConfigureGraphQLSchema<ChatSchema>(app, Common.ChatEndpoint);
+            ConfigureGraphQLSchema<StarWarsSchema>(app, Common.StarWarsEndpoint);
 
-			app.UseGraphiQLServer(new GraphiQLOptions {
-				GraphiQLPath = "/ui/graphiql",
-				GraphQLEndPoint = Common.StarWarsEndpoint
-			});
-			app.UseGraphQLPlayground(new GraphQLPlaygroundOptions {
-				Path = "/ui/playground",
-				GraphQLEndPoint = Common.ChatEndpoint
-			});
-		}
+            app.UseGraphiQLServer(new GraphiQLOptions
+            {
+                GraphiQLPath = "/ui/graphiql",
+                GraphQLEndPoint = Common.StarWarsEndpoint
+            });
+            app.UseGraphQLPlayground(new GraphQLPlaygroundOptions
+            {
+                Path = "/ui/playground",
+                GraphQLEndPoint = Common.ChatEndpoint
+            });
+        }
 
-		private void ConfigureGraphQLSchema<TSchema>(IApplicationBuilder app, string endpoint) where TSchema: Schema
-		{
-			app.UseGraphQLWebSockets<TSchema>(endpoint);
-			app.UseGraphQL<TSchema>(endpoint);
-		}
-	}
+        private void ConfigureGraphQLSchema<TSchema>(IApplicationBuilder app, string endpoint) where TSchema : Schema
+        {
+            app.UseGraphQLWebSockets<TSchema>(endpoint);
+            app.UseGraphQL<TSchema>(endpoint);
+        }
+    }
 }

--- a/tests/IntegrationTestServer/Startup.cs
+++ b/tests/IntegrationTestServer/Startup.cs
@@ -56,18 +56,18 @@ namespace IntegrationTestServer
 
             app.UseWebSockets();
 
-            ConfigureGraphQLSchema<ChatSchema>(app, Common.ChatEndpoint);
-            ConfigureGraphQLSchema<StarWarsSchema>(app, Common.StarWarsEndpoint);
+            ConfigureGraphQLSchema<ChatSchema>(app, Common.CHAT_ENDPOINT);
+            ConfigureGraphQLSchema<StarWarsSchema>(app, Common.STAR_WARS_ENDPOINT);
 
             app.UseGraphiQLServer(new GraphiQLOptions
             {
                 GraphiQLPath = "/ui/graphiql",
-                GraphQLEndPoint = Common.StarWarsEndpoint
+                GraphQLEndPoint = Common.STAR_WARS_ENDPOINT
             });
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions
             {
                 Path = "/ui/playground",
-                GraphQLEndPoint = Common.ChatEndpoint
+                GraphQLEndPoint = Common.CHAT_ENDPOINT
             });
         }
 


### PR DESCRIPTION
Use `.editorconfig` from graphql-dotnet and fix style issues...

Kudos to whoever wrote the `dotnet-format` tool 😉 

fixes #195 