### PR TITLE
Allow configuration of ClientWebsocketOptions

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 
 namespace GraphQL.Client.Http
@@ -52,5 +53,10 @@ namespace GraphQL.Client.Http
         /// This callback is called after successfully establishing a websocket connection but before any regular request is made. 
         /// </summary>
         public Func<GraphQLHttpClient, Task> OnWebsocketConnected { get; set; } = client => Task.CompletedTask;
+
+        /// <summary>
+        /// Configure additional websocket options (i.e. headers). This will not be invoked on Windows 7 when targeting .NET Framework 4.x. 
+        /// </summary>
+        public Action<ClientWebSocketOptions> ConfigureWebsocketOptions { get; set; } = options => { };
     }
 }

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -399,12 +399,13 @@ namespace GraphQL.Client.Http.Websocket
 						nativeWebSocket.Options.AddSubProtocol("graphql-ws");
 						nativeWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
 						nativeWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
-						break;
+                        Options.ConfigureWebsocketOptions(nativeWebSocket.Options);
+                        break;
 					case System.Net.WebSockets.Managed.ClientWebSocket managedWebSocket:
 						managedWebSocket.Options.AddSubProtocol("graphql-ws");
 						managedWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
 						managedWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
-						break;
+                        break;
 					default:
 						throw new NotSupportedException($"unknown websocket type {_clientWebSocket.GetType().Name}");
 				}
@@ -413,6 +414,7 @@ namespace GraphQL.Client.Http.Websocket
                 _clientWebSocket.Options.AddSubProtocol("graphql-ws");
                 _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
                 _clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
+                Options.ConfigureWebsocketOptions(_clientWebSocket.Options);
 #endif
                 return _initializeWebSocketTask = ConnectAsync(_internalCancellationToken);
             }
@@ -609,7 +611,7 @@ namespace GraphQL.Client.Http.Websocket
         /// Task to await the completion (a.k.a. disposal) of this websocket.
         /// </summary> 
         /// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
-        public Task Completion { get; private set; }
+        public Task? Completion { get; private set; }
 
         private readonly object _completedLocker = new object();
         private async Task CompleteAsync()


### PR DESCRIPTION
Adds a property `Action<ClientWebsocketOptions> ConfigureWebsocketOptions` to `GraphQLHttpClientOptions` to allow additional configuration of the websocket (i.e. adding headers).

Resolves #179, resolves #221 

