### PR TITLE
Dim/ws fixes

### DIFF
--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -4,6 +4,17 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Client.Abstractions.Websocket
 {
+
+    public class GraphQLInitAuthWebsocketRequest : GraphQLWebSocketRequest
+    {
+        public GraphQLInitAuthWebsocketRequest(string id, string token)
+        {
+            Id = id;
+            Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT;
+            this[PAYLOAD_KEY] = new Dictionary<string, string>() { { "Authorization", token } };
+        }
+    }
+
     /// <summary>
     /// A Subscription Request
     /// </summary>

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -4,17 +4,6 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Client.Abstractions.Websocket
 {
-
-    public class GraphQLInitAuthWebsocketRequest : GraphQLWebSocketRequest
-    {
-        public GraphQLInitAuthWebsocketRequest(string id, string token)
-        {
-            Id = id;
-            Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT;
-            this[PAYLOAD_KEY] = new Dictionary<string, string>() { { "Authorization", token } };
-        }
-    }
-
     /// <summary>
     /// A Subscription Request
     /// </summary>

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -112,15 +112,23 @@ namespace GraphQL.Client.Http.Websocket
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_STOP
                         };
-                        //var initRequest = new GraphQLWebSocketRequest
-                        //{
-                        //    Id = startRequest.Id,
-                        //    Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                        //    Payload = new Dictionary<string, object>() { { "Authorization", "BLABLA" } } as GraphQLRequest
-                        //};
 
+                        var initRequest = new GraphQLWebSocketRequest
+                        {
+                            Id = startRequest.Id,
+                            Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
+                        };
+                        
+
+                        // Check if there's an authorization header on the base client.
+                        // NOTE: perhaps there's a better way? 
                         var authHeader = _client.HttpClient.DefaultRequestHeaders.GetValues("Authorization").FirstOrDefault();
-                        var initRequest = new GraphQLInitAuthWebsocketRequest(startRequest.Id, authHeader);
+
+                        // If the auth header actually exist, send it in the connection_init request
+                        if (authHeader != null)
+                        {
+                            initRequest[GraphQLWebSocketRequest.PAYLOAD_KEY] = new Dictionary<string, string>() { { "Authorization", authHeader } };
+                        }
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>
                             IncomingMessageStream

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -114,6 +114,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
+                            Payload = new GraphQLRequest()
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>
@@ -549,16 +550,22 @@ namespace GraphQL.Client.Http.Websocket
                 _internalCancellationToken.ThrowIfCancellationRequested();
                 ms.Seek(0, SeekOrigin.Begin);
 
-                if (webSocketReceiveResult.MessageType == WebSocketMessageType.Text)
+                switch (webSocketReceiveResult.MessageType)
                 {
-                    var response = await _client.JsonSerializer.DeserializeToWebsocketResponseWrapperAsync(ms);
-                    response.MessageBytes = ms.ToArray();
-                    Debug.WriteLine($"{response.MessageBytes.Length} bytes received for id {response.Id} on websocket {_clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
-                    return response;
-                }
-                else
-                {
-                    throw new NotSupportedException("binary websocket messages are not supported");
+                    case WebSocketMessageType.Text:
+                        var response = await _client.JsonSerializer.DeserializeToWebsocketResponseWrapperAsync(ms);
+                        response.MessageBytes = ms.ToArray();
+                        Debug.WriteLine($"{response.MessageBytes.Length} bytes received for id {response.Id} on websocket {_clientWebSocket.GetHashCode()} (thread {Thread.CurrentThread.ManagedThreadId})...");
+                        return response;
+
+                    case WebSocketMessageType.Close:
+                        var closeResponse = await _client.JsonSerializer.DeserializeToWebsocketResponseWrapperAsync(ms);
+                        closeResponse.MessageBytes = ms.ToArray();
+                        Debug.WriteLine($"Connection closed by the server.");
+                        throw new Exception("Connection closed by the server.");
+
+                    case WebSocketMessageType.Binary:
+                        throw new NotSupportedException("binary websocket messages are not supported");
                 }
             }
             catch (Exception e)
@@ -629,7 +636,7 @@ namespace GraphQL.Client.Http.Websocket
             _exceptionSubject?.OnCompleted();
             _exceptionSubject?.Dispose();
             _internalCancellationTokenSource.Dispose();
-            
+
             Debug.WriteLine("GraphQLHttpWebSocket disposed");
         }
 


### PR DESCRIPTION
Attempts a fix #269 and potentially fixes (or clarifies more) the problem on #250. Defintively fixes the [problem on our end](https://github.com/specklesystems/Core/issues/15)!

What's the issue at hand: when connecting to an apollo server subscription endpoint, if an authorization header is present, the server expects it passed in the `connection_init` event like so:

```
{"id":"9ba247df77e64de9a68189c46d3c4300","type":"connection_init","payload":{"Authorization":"etc"}}
```

graphql-client was not passing that along. This PR simply checks in the provided httpClient if there is  an `Authorization` header and, if so, passes it along by adding it to the `connection_init` request in `CreateSubscriptionStream`:

```
initRequest[GraphQLWebSocketRequest.PAYLOAD_KEY] = new Dictionary<string, string>() { { "Authorization", authHeader } };
```

Relying on a custom http client being passed with custom default request headers as we didn't find out a better way of setting them currently. 

Happy to rework if there's a better way of doing this. 

---
To clarify re  #250: we were getting the same "binary websocket messages are not supported" error, but the actually it was a close event. Changed those `if else` statements to a switch :) 