### PR TITLE
Blazor WebAssembly support: added try-catch for unsupported properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,9 @@ subscription.Dispose();
 * [GitHub GraphQL API Docs](https://developer.github.com/v4/guides/forming-calls/)
 * [GitHub GraphQL Explorer](https://developer.github.com/v4/explorer/)
 * [GitHub GraphQL Endpoint](https://api.github.com/graphql)
+
+## Blazor WebAssembly Limitations
+
+Blazor WebAssembly differs from other platforms as it does not support all features of other .NET runtime implementations. For instance, the following WebSocket options properties are not supported and will not be set:
+* [ClientCertificates](https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocketoptions.clientcertificates?view=netcore-3.1#System_Net_WebSockets_ClientWebSocketOptions_ClientCertificates)
+* [UseDefaultCredentials](https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocketoptions.usedefaultcredentials?view=netcore-3.1)

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -66,10 +66,6 @@ namespace GraphQL.Client.Http
                 HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(GetType().Assembly.GetName().Name, GetType().Assembly.GetName().Version.ToString()));
 
             _lazyHttpWebSocket = new Lazy<GraphQLHttpWebSocket>(() => new GraphQLHttpWebSocket(GetWebSocketUri(), this));
-            if ((Options.EndPoint?.Scheme == "wss") || (Options.EndPoint?.Scheme == "ws"))
-            {
-                Options.UseWebSocketForQueriesAndMutations = true;
-            }
         }
 
         #endregion
@@ -159,12 +155,8 @@ namespace GraphQL.Client.Http
 
         private Uri GetWebSocketUri()
         {
-            string webSocketSchema = Options.EndPoint.Scheme == "https"
-                ? "wss"
-                : Options.EndPoint.Scheme == "http"
-                ? "ws"
-                : Options.EndPoint.Scheme;
-            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}{Options.EndPoint.Query}");
+            string webSocketSchema = Options.EndPoint.Scheme == "https" ? "wss" : "ws";
+            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}");
         }
 
         #endregion

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -66,6 +66,10 @@ namespace GraphQL.Client.Http
                 HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(GetType().Assembly.GetName().Name, GetType().Assembly.GetName().Version.ToString()));
 
             _lazyHttpWebSocket = new Lazy<GraphQLHttpWebSocket>(() => new GraphQLHttpWebSocket(GetWebSocketUri(), this));
+            if ((Options.EndPoint?.Scheme == "wss") || (Options.EndPoint?.Scheme == "ws"))
+            {
+                Options.UseWebSocketForQueriesAndMutations = true;
+            }
         }
 
         #endregion
@@ -155,8 +159,12 @@ namespace GraphQL.Client.Http
 
         private Uri GetWebSocketUri()
         {
-            string webSocketSchema = Options.EndPoint.Scheme == "https" ? "wss" : "ws";
-            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}");
+            string webSocketSchema = Options.EndPoint.Scheme == "https"
+                ? "wss"
+                : Options.EndPoint.Scheme == "http"
+                ? "ws"
+                : Options.EndPoint.Scheme;
+            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}{Options.EndPoint.Query}");
         }
 
         #endregion

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -619,7 +619,7 @@ namespace GraphQL.Client.Http.Websocket
 
         /// <summary>
         /// Task to await the completion (a.k.a. disposal) of this websocket.
-        /// </summary>
+        /// </summary> 
         /// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
         public Task? Completion { get; private set; }
 
@@ -643,7 +643,7 @@ namespace GraphQL.Client.Http.Websocket
             _exceptionSubject?.OnCompleted();
             _exceptionSubject?.Dispose();
             _internalCancellationTokenSource.Dispose();
-
+            
             Debug.WriteLine("GraphQLHttpWebSocket disposed");
         }
 

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -407,8 +407,22 @@ namespace GraphQL.Client.Http.Websocket
 #else
                 _clientWebSocket = new ClientWebSocket();
                 _clientWebSocket.Options.AddSubProtocol("graphql-ws");
-                _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
-                _clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
+                try
+                {
+                    _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
+                }
+                catch(PlatformNotSupportedException)
+                {
+                    Debug.WriteLine("unable to set Options.ClientCertificates property; platform does not support it");
+                }
+                try
+                {
+                    _clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
+                }
+                catch(PlatformNotSupportedException)
+                {
+                    Debug.WriteLine("unable to set Options.UseDefaultCredentials property; platform does not support it");
+                }
                 Options.ConfigureWebsocketOptions(_clientWebSocket.Options);
 #endif
                 return _initializeWebSocketTask = ConnectAsync(_internalCancellationToken);
@@ -605,7 +619,7 @@ namespace GraphQL.Client.Http.Websocket
 
         /// <summary>
         /// Task to await the completion (a.k.a. disposal) of this websocket.
-        /// </summary> 
+        /// </summary>
         /// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
         public Task? Completion { get; private set; }
 
@@ -629,7 +643,7 @@ namespace GraphQL.Client.Http.Websocket
             _exceptionSubject?.OnCompleted();
             _exceptionSubject?.Dispose();
             _internalCancellationTokenSource.Dispose();
-            
+
             Debug.WriteLine("GraphQLHttpWebSocket disposed");
         }
 

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -411,7 +411,7 @@ namespace GraphQL.Client.Http.Websocket
                 {
                     _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
                 }
-                catch(PlatformNotSupportedException)
+                catch (PlatformNotSupportedException)
                 {
                     Debug.WriteLine("unable to set Options.ClientCertificates property; platform does not support it");
                 }
@@ -419,7 +419,7 @@ namespace GraphQL.Client.Http.Websocket
                 {
                     _clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
                 }
-                catch(PlatformNotSupportedException)
+                catch (PlatformNotSupportedException)
                 {
                     Debug.WriteLine("unable to set Options.UseDefaultCredentials property; platform does not support it");
                 }


### PR DESCRIPTION
Addresses remaining compatibility issues for Blazor WebAssembly support (see #262)