### PR TITLE
Allow wss:// scheme, preserve uri query parameters

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -66,6 +66,10 @@ namespace GraphQL.Client.Http
                 HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(GetType().Assembly.GetName().Name, GetType().Assembly.GetName().Version.ToString()));
 
             _lazyHttpWebSocket = new Lazy<GraphQLHttpWebSocket>(() => new GraphQLHttpWebSocket(GetWebSocketUri(), this));
+            if ((Options.EndPoint?.Scheme == "wss") || (Options.EndPoint?.Scheme == "ws"))
+            {
+                Options.UseWebSocketForQueriesAndMutations = true;
+            }
         }
 
         #endregion
@@ -155,8 +159,12 @@ namespace GraphQL.Client.Http
 
         private Uri GetWebSocketUri()
         {
-            string webSocketSchema = Options.EndPoint.Scheme == "https" ? "wss" : "ws";
-            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}");
+            string webSocketSchema = Options.EndPoint.Scheme == "https"
+                ? "wss"
+                : Options.EndPoint.Scheme == "http"
+                ? "ws"
+                : Options.EndPoint.Scheme;
+            return new Uri($"{webSocketSchema}://{Options.EndPoint.Host}:{Options.EndPoint.Port}{Options.EndPoint.AbsolutePath}{Options.EndPoint.Query}");
         }
 
         #endregion


### PR DESCRIPTION
Fixes #275 - Endpoint scheme and query parameters are ignored when opening websocket connection

I also added the change to automatically switch `Options.UseWebSocketForQueriesAndMutations` to `true` when the endpoint scheme is a websocket.