### PR TITLE
check if running in WebAssembly instead of catching PlatformNotSupportedException

### DIFF
--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -408,21 +408,11 @@ namespace GraphQL.Client.Http.Websocket
 #else
                 _clientWebSocket = new ClientWebSocket();
                 _clientWebSocket.Options.AddSubProtocol("graphql-ws");
-                try
+                if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("WEBASSEMBLY")))
                 {
+                    // the following properties are not supported in Blazor WebAssembly and throw a PlatformNotSupportedException error when accessed
                     _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    Debug.WriteLine("unable to set Options.ClientCertificates property; platform does not support it");
-                }
-                try
-                {
                     _clientWebSocket.Options.UseDefaultCredentials = ((HttpClientHandler)Options.HttpMessageHandler).UseDefaultCredentials;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    Debug.WriteLine("unable to set Options.UseDefaultCredentials property; platform does not support it");
                 }
                 Options.ConfigureWebsocketOptions(_clientWebSocket.Options);
 #endif
@@ -627,7 +617,7 @@ namespace GraphQL.Client.Http.Websocket
 
         /// <summary>
         /// Task to await the completion (a.k.a. disposal) of this websocket.
-        /// </summary> 
+        /// </summary>
         /// Async disposal as recommended by Stephen Cleary (https://blog.stephencleary.com/2013/03/async-oop-6-disposal.html)
         public Task? Completion { get; private set; }
 


### PR DESCRIPTION
This pull-request fixes https://github.com/graphql-dotnet/graphql-client/issues/280

I used explicit class names for `RuntimeInformation` and `OSPlatform` instead of adding a using statement that would only apply conditionally. Let me know which style you prefer.

There was also a trailing space that was automatically nuked by my editor, which I didn't catch before pushing my changes. Let me know if you'd like it back.

I tested this on a Blazor WebAssembly app built with .NET Core 3.1.402. I did NOT test it on another target.