### PR TITLE
Adding initialization headers to a WebSocket GraphQL client

### DIFF
--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQL.Client.Abstractions.Websocket.csproj
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQL.Client.Abstractions.Websocket.csproj
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <Description>Abstractions for the Websocket transport used in GraphQL.Client</Description>
 	  <TargetFramework>netstandard2.0</TargetFramework>
-	  <Version>3.2.0</Version>
-	  <AssemblyVersion>3.2.0.0</AssemblyVersion>
+	  <Version>1.0.0</Version>
+	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQL.Client.Abstractions.Websocket.csproj
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQL.Client.Abstractions.Websocket.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Description>Abstractions for the Websocket transport used in GraphQL.Client</Description>
 	  <TargetFramework>netstandard2.0</TargetFramework>
+	  <Version>3.2.0</Version>
+	  <AssemblyVersion>3.2.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -34,9 +34,9 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// <summary>
         /// The payload of the websocket request
         /// </summary>
-        public GraphQLRequest Payload
+        public object Payload
         {
-            get => ContainsKey(PAYLOAD_KEY) ? (GraphQLRequest)this[PAYLOAD_KEY] : null;
+            get => ContainsKey(PAYLOAD_KEY) ? this[PAYLOAD_KEY] : null;
             set => this[PAYLOAD_KEY] = value;
         }
 

--- a/src/GraphQL.Client.Abstractions/GraphQL.Client.Abstractions.csproj
+++ b/src/GraphQL.Client.Abstractions/GraphQL.Client.Abstractions.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>Abstractions for GraphQL.Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>3.2.0</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Abstractions/GraphQL.Client.Abstractions.csproj
+++ b/src/GraphQL.Client.Abstractions/GraphQL.Client.Abstractions.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <Description>Abstractions for GraphQL.Client</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>3.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <Description>A serializer implementation for GraphQL.Client using Newtonsoft.Json as underlying JSON library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>3.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
+++ b/src/GraphQL.Client.Serializer.Newtonsoft/GraphQL.Client.Serializer.Newtonsoft.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>A serializer implementation for GraphQL.Client using Newtonsoft.Json as underlying JSON library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>3.2.0</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GraphQL.Client/GraphQL.Client.csproj
+++ b/src/GraphQL.Client/GraphQL.Client.csproj
@@ -5,14 +5,14 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <RootNamespace>GraphQL.Client.Http</RootNamespace>
-    <Authors>Deinok,Alexander Rose,graphql-dotnet, Cityzenith LLC</Authors>
-    <Company>Deinok,Alexander Rose,graphql-dotnet, Cityzenith LLC</Company>
-    <PackageProjectUrl>https://github.com/cityzenith/graphql-client</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/cityzenith/graphql-client</RepositoryUrl>
+    <Authors>Deinok,Alexander Rose,graphql-dotnet</Authors>
+    <Company>Deinok,Alexander Rose,graphql-dotnet</Company>
+    <PackageProjectUrl>https://github.com/graphql-dotnet/graphql-client</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/graphql-dotnet/graphql-client</RepositoryUrl>
     <PackageId>GraphQL.Client</PackageId>
-    <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.0</FileVersion>
-    <Version>3.2.0</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/GraphQL.Client/GraphQL.Client.csproj
+++ b/src/GraphQL.Client/GraphQL.Client.csproj
@@ -5,6 +5,14 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <RootNamespace>GraphQL.Client.Http</RootNamespace>
+    <Authors>Deinok,Alexander Rose,graphql-dotnet, Cityzenith LLC</Authors>
+    <Company>Deinok,Alexander Rose,graphql-dotnet, Cityzenith LLC</Company>
+    <PackageProjectUrl>https://github.com/cityzenith/graphql-client</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cityzenith/graphql-client</RepositoryUrl>
+    <PackageId>GraphQL.Client</PackageId>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
+    <Version>3.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -35,6 +36,11 @@ namespace GraphQL.Client.Http
         /// The Options	to be used
         /// </summary>
         public GraphQLHttpClientOptions Options { get; }
+
+        /// <summary>
+        /// The custom web socket headers for initialization of connection
+        /// </summary>
+        public Dictionary<string, string> WebSocketHeaders { get; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Publishes all exceptions which occur inside the websocket receive stream (i.e. for logging purposes)

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -114,7 +114,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                            Payload = new GraphQLRequest()
+                            Payload = _client.WebSocketHeaders.Count > 0 ? _client.WebSocketHeaders : null
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>

--- a/src/GraphQL.Primitives/GraphQL.Primitives.csproj
+++ b/src/GraphQL.Primitives/GraphQL.Primitives.csproj
@@ -6,7 +6,7 @@
     <Description>GraphQL basic types</Description>
     <RootNamespace>GraphQL</RootNamespace>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>3.2.0</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   
 </Project>

--- a/src/GraphQL.Primitives/GraphQL.Primitives.csproj
+++ b/src/GraphQL.Primitives/GraphQL.Primitives.csproj
@@ -6,6 +6,7 @@
     <Description>GraphQL basic types</Description>
     <RootNamespace>GraphQL</RootNamespace>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>3.2.0</Version>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
Not just authorization, but other headers could be added that may be required when initializing a web socket connection.
It supports adding authorization tokens