### PR TITLE
fix Blazor WASM check

### DIFF
--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -408,7 +408,7 @@ namespace GraphQL.Client.Http.Websocket
 #else
                 _clientWebSocket = new ClientWebSocket();
                 _clientWebSocket.Options.AddSubProtocol("graphql-ws");
-                if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("WEBASSEMBLY")))
+                if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("BROWSER")))
                 {
                     // the following properties are not supported in Blazor WebAssembly and throw a PlatformNotSupportedException error when accessed
                     _clientWebSocket.Options.ClientCertificates = ((HttpClientHandler)Options.HttpMessageHandler).ClientCertificates;


### PR DESCRIPTION
This fix correctly detects Blazor WebAssembly mode, which doesn't allow certain operations.