### PR TITLE
GraphQLRequest fixes

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpRequest.cs
+++ b/src/GraphQL.Client/GraphQLHttpRequest.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Client.Http
         {
         }
 
-        public GraphQLHttpRequest(GraphQLRequest other): base(other.Query, other.Variables, other.OperationName)
+        public GraphQLHttpRequest(GraphQLRequest other): base(other)
         {
         }
 

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -49,6 +49,14 @@ namespace GraphQL
             OperationName = operationName;
         }
 
+        public GraphQLRequest(IEnumerable<KeyValuePair<string, object>> values)
+        {
+            foreach(var kv in values)
+            {
+                Add(kv.Key, kv.Value);
+            }
+        }
+
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object
         /// </summary>
@@ -86,7 +94,7 @@ namespace GraphQL
         {
             unchecked
             {
-                var hashCode = Query.GetHashCode();
+                var hashCode = Query?.GetHashCode() ?? 0;
                 hashCode = (hashCode * 397) ^ OperationName?.GetHashCode() ?? 0;
                 hashCode = (hashCode * 397) ^ Variables?.GetHashCode() ?? 0;
                 return hashCode;

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -84,16 +84,7 @@ namespace GraphQL
         /// <summary>
         /// <inheritdoc cref="object.GetHashCode"/>
         /// </summary>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = Query?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ OperationName?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ Variables?.GetHashCode() ?? 0;
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => (Query, OperationName, Variables).GetHashCode();
 
         /// <summary>
         /// Tests whether two specified <see cref="GraphQLRequest"/> instances are equivalent

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -49,9 +49,9 @@ namespace GraphQL
             OperationName = operationName;
         }
 
-        public GraphQLRequest(IEnumerable<KeyValuePair<string, object>> values)
+        public GraphQLRequest(GraphQLRequest other)
         {
-            foreach(var kv in values)
+            foreach(var kv in other)
             {
                 Add(kv.Key, kv.Value);
             }

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -49,13 +49,7 @@ namespace GraphQL
             OperationName = operationName;
         }
 
-        public GraphQLRequest(GraphQLRequest other)
-        {
-            foreach(var kv in other)
-            {
-                Add(kv.Key, kv.Value);
-            }
-        }
+        public GraphQLRequest(GraphQLRequest other): base(other) { }
 
         /// <summary>
         /// Returns a value that indicates whether this instance is equal to a specified object


### PR DESCRIPTION
1. Preserve all entries in `GraphQLRequest` when using the copy constructor.
2. Avoid `NullReferenceException` on `GetHashCode()` when `Query` is not set.