### PR TITLE
Add websocket ConnectionParams object 

### DIFF
--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         public const string PAYLOAD_KEY = "payload";
 
         /// <summary>
-        /// The Identifier of the Response
+        /// The Identifier of the request
         /// </summary>
         public string Id
         {
@@ -34,7 +34,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// <summary>
         /// The payload of the websocket request
         /// </summary>
-        public object Payload
+        public object? Payload
         {
             get => TryGetValue(PAYLOAD_KEY, out object value) ? value : null;
             set => this[PAYLOAD_KEY] = value;

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -34,9 +34,9 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// <summary>
         /// The payload of the websocket request
         /// </summary>
-        public GraphQLRequest Payload
+        public object Payload
         {
-            get => ContainsKey(PAYLOAD_KEY) ? (GraphQLRequest)this[PAYLOAD_KEY] : null;
+            get => ContainsKey(PAYLOAD_KEY) ? this[PAYLOAD_KEY] : null;
             set => this[PAYLOAD_KEY] = value;
         }
 

--- a/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
+++ b/src/GraphQL.Client.Abstractions.Websocket/GraphQLWebSocketRequest.cs
@@ -18,7 +18,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// </summary>
         public string Id
         {
-            get => ContainsKey(ID_KEY) ? (string)this[ID_KEY] : null;
+            get => TryGetValue(ID_KEY, out object value) ? (string)value : null;
             set => this[ID_KEY] = value;
         }
 
@@ -27,7 +27,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// </summary>
         public string Type
         {
-            get => ContainsKey(TYPE_KEY) ? (string)this[TYPE_KEY] : null;
+            get => TryGetValue(TYPE_KEY, out object value) ? (string)value : null;
             set => this[TYPE_KEY] = value;
         }
 
@@ -36,7 +36,7 @@ namespace GraphQL.Client.Abstractions.Websocket
         /// </summary>
         public object Payload
         {
-            get => ContainsKey(PAYLOAD_KEY) ? this[PAYLOAD_KEY] : null;
+            get => TryGetValue(PAYLOAD_KEY, out object value) ? value : null;
             set => this[PAYLOAD_KEY] = value;
         }
 

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -56,5 +56,11 @@ namespace GraphQL.Client.Http
         /// Configure additional websocket options (i.e. headers). This will not be invoked on Windows 7 when targeting .NET Framework 4.x. 
         /// </summary>
         public Action<ClientWebSocketOptions> ConfigureWebsocketOptions { get; set; } = options => { };
+
+        /// <summary>
+        /// The `ConnectionParams` object sent with the GQL_CONNECTION_INIT message on establishing a websocket connection.
+        /// See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init.
+        /// </summary>
+        public object? WebSocketConnectionParams { get; set; } = null;
     }
 }

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -58,9 +58,9 @@ namespace GraphQL.Client.Http
         public Action<ClientWebSocketOptions> ConfigureWebsocketOptions { get; set; } = options => { };
 
         /// <summary>
-        /// The `ConnectionParams` object sent with the GQL_CONNECTION_INIT message on establishing a websocket connection.
+        /// Sets the `ConnectionParams` object sent with the GQL_CONNECTION_INIT message on establishing a GraphQL websocket connection.
         /// See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init.
         /// </summary>
-        public Func<object?> SetWebSocketConnectionParams { get; set; } = () => null;
+        public Func<object?> SetWebSocketConnectionInitPayload { get; set; } = () => null;
     }
 }

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -61,6 +61,6 @@ namespace GraphQL.Client.Http
         /// Sets the `ConnectionParams` object sent with the GQL_CONNECTION_INIT message on establishing a GraphQL websocket connection.
         /// See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init.
         /// </summary>
-        public Func<object?> SetWebSocketConnectionInitPayload { get; set; } = () => null;
+        public Func<GraphQLHttpClientOptions, object?> ConfigureWebSocketConnectionInitPayload { get; set; } = options => null;
     }
 }

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -61,6 +61,6 @@ namespace GraphQL.Client.Http
         /// The `ConnectionParams` object sent with the GQL_CONNECTION_INIT message on establishing a websocket connection.
         /// See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init.
         /// </summary>
-        public object? WebSocketConnectionParams { get; set; } = null;
+        public Func<object?> SetWebSocketConnectionParams { get; set; } = () => null;
     }
 }

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -115,7 +115,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                            Payload = Options.SetWebSocketConnectionInitPayload()
+                            Payload = Options.ConfigureWebSocketConnectionInitPayload(Options)
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -98,12 +98,13 @@ namespace GraphQL.Client.Http.Websocket
                     Observable.Create<GraphQLResponse<TResponse>>(async observer =>
                     {
                         Debug.WriteLine($"Create observable thread id: {Thread.CurrentThread.ManagedThreadId}");
-                        await _client.Options.PreprocessRequest(request, _client);
+                        var preprocessedRequest = await _client.Options.PreprocessRequest(request, _client);
+
                         var startRequest = new GraphQLWebSocketRequest
                         {
                             Id = Guid.NewGuid().ToString("N"),
                             Type = GraphQLWebSocketMessageType.GQL_START,
-                            Payload = request
+                            Payload = preprocessedRequest
                         };
                         var stopRequest = new GraphQLWebSocketRequest
                         {
@@ -114,7 +115,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                            Payload = Options.WebSocketConnectionParams
+                            Payload = Options.SetWebSocketConnectionParams()
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -105,7 +105,7 @@ namespace GraphQL.Client.Http.Websocket
                             Type = GraphQLWebSocketMessageType.GQL_START,
                             Payload = request
                         };
-                        var closeRequest = new GraphQLWebSocketRequest
+                        var stopRequest = new GraphQLWebSocketRequest
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_STOP
@@ -114,7 +114,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                            Payload = new GraphQLRequest()
+                            Payload = Options.WebSocketConnectionParams
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>
@@ -179,8 +179,8 @@ namespace GraphQL.Client.Http.Websocket
 
                                 try
                                 {
-                                    Debug.WriteLine($"sending close message on subscription {startRequest.Id}");
-                                    await QueueWebSocketRequest(closeRequest);
+                                    Debug.WriteLine($"sending stop message on subscription {startRequest.Id}");
+                                    await QueueWebSocketRequest(stopRequest);
                                 }
                                 // do not break on disposing
                                 catch (OperationCanceledException) { }

--- a/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLHttpWebSocket.cs
@@ -115,7 +115,7 @@ namespace GraphQL.Client.Http.Websocket
                         {
                             Id = startRequest.Id,
                             Type = GraphQLWebSocketMessageType.GQL_CONNECTION_INIT,
-                            Payload = Options.SetWebSocketConnectionParams()
+                            Payload = Options.SetWebSocketConnectionInitPayload()
                         };
 
                         var observable = Observable.Create<GraphQLResponse<TResponse>>(o =>

--- a/src/GraphQL.Primitives/GraphQLRequest.cs
+++ b/src/GraphQL.Primitives/GraphQLRequest.cs
@@ -18,7 +18,7 @@ namespace GraphQL
         /// </summary>
         public string Query
         {
-            get => ContainsKey(QUERY_KEY) ? (string)this[QUERY_KEY] : null;
+            get => TryGetValue(QUERY_KEY, out object value) ? (string)value : null;
             set => this[QUERY_KEY] = value;
         }
 
@@ -27,7 +27,7 @@ namespace GraphQL
         /// </summary>
         public string? OperationName
         {
-            get => ContainsKey(OPERATION_NAME_KEY) ? (string)this[OPERATION_NAME_KEY] : null;
+            get => TryGetValue(OPERATION_NAME_KEY, out object value) ? (string)value : null;
             set => this[OPERATION_NAME_KEY] = value;
         }
 
@@ -36,7 +36,7 @@ namespace GraphQL
         /// </summary>
         public object? Variables
         {
-            get => ContainsKey(VARIABLES_KEY) ? this[VARIABLES_KEY] : null;
+            get => TryGetValue(VARIABLES_KEY, out object value) ? value : null;
             set => this[VARIABLES_KEY] = value;
         }
 


### PR DESCRIPTION
This is specified in the [Apollo GraphQL over WebSocket Protocol specification](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init) and there is currently no way to set this.

Fixes #269, fixes #250

This does essentially the same as #285 albeit keeping Apollos naming convention. 