### PR TITLE
Add PolymorphicTypenameConverter class to handle __typename deserialization 

### DIFF
--- a/src/GraphQL.Client.Serializer.SystemTextJson/PolymorphicTypenameConverter.cs
+++ b/src/GraphQL.Client.Serializer.SystemTextJson/PolymorphicTypenameConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GraphQL.Client.Serializer.SystemTextJson
+{
+    public abstract class PolymorphicTypenameConverter<T> : JsonConverter<T>
+    {
+        protected abstract Type Descriminator(string typename);
+
+        public override bool CanConvert(Type typeToConvert) =>
+            typeof(T).IsAssignableFrom(typeToConvert);
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var clone = reader; // cause its a struct
+
+            if(clone.TokenType == JsonTokenType.StartObject)
+                clone.Read();
+            if(clone.TokenType != JsonTokenType.PropertyName || clone.GetString() != "__typename")
+                throw new JsonException();
+
+            clone.Read();
+            var type = Descriminator(clone.GetString());
+            object deserialize = JsonSerializer.Deserialize(ref reader, type, options);
+            return (T)deserialize;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T obj, JsonSerializerOptions options) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Attached a helper class I found very useful to handle fragments and  __typename deserialization:

Usage:

```csharp
            [JsonConverter(typeof(DiscriminateEvent))]
            public Event Event { get; set; }

            class DiscriminateEvent : PolymorphicTypenameConverter<Event>
            {
                protected override Type Descriminator(string typename) =>
                    typename switch
                    {
                        "EventA" => typeof(EventA),
                        "EventB" => typeof(EventB),
                        _ => typeof(Event)
                    };
            }
```

I think there should be also a example within the readme cause its not obvious how to use it. 

But for now I want to know what you think first and if its a nice addition.