### PR TITLE
Add TestServer support for GraphQLHttpClient #354

### DIFF
--- a/GraphQL.Client.sln
+++ b/GraphQL.Client.sln
@@ -65,6 +65,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{89
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Client.Example", "examples\GraphQL.Client.Example\GraphQL.Client.Example.csproj", "{6B13B87D-1EF4-485F-BC5D-891E2F4DA6CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Client.TestHost", "src\GraphQL.Client.TestHost\GraphQL.Client.TestHost.csproj", "{01AE8466-3E48-4988-81F1-7F93F1531302}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,10 @@ Global
 		{6B13B87D-1EF4-485F-BC5D-891E2F4DA6CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B13B87D-1EF4-485F-BC5D-891E2F4DA6CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B13B87D-1EF4-485F-BC5D-891E2F4DA6CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01AE8466-3E48-4988-81F1-7F93F1531302}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01AE8466-3E48-4988-81F1-7F93F1531302}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01AE8466-3E48-4988-81F1-7F93F1531302}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01AE8466-3E48-4988-81F1-7F93F1531302}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -146,6 +152,7 @@ Global
 		{0D307BAD-27AE-4A5D-8764-4AA2620B01E9} = {0B0EDB0F-FF67-4B78-A8DB-B5C23E1FEE8C}
 		{7FFFEC00-D751-4FFC-9FD4-E91858F9A1C5} = {47C98B55-08F1-4428-863E-2C5C876DEEFE}
 		{6B13B87D-1EF4-485F-BC5D-891E2F4DA6CD} = {89AD33AB-64F6-4F82-822F-21DF7A10CEC0}
+		{01AE8466-3E48-4988-81F1-7F93F1531302} = {47C98B55-08F1-4428-863E-2C5C876DEEFE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {387AC1AC-F90C-4EF8-955A-04D495C75AF4}

--- a/src/GraphQL.Client.TestHost/GraphQL.Client.TestHost.csproj
+++ b/src/GraphQL.Client.TestHost/GraphQL.Client.TestHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\GraphQL.Client\GraphQL.Client.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/GraphQL.Client.TestHost/TestServerExtensions.cs
+++ b/src/GraphQL.Client.TestHost/TestServerExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Http;
+using Microsoft.AspNetCore.TestHost;
+
+namespace GraphQL.Client.TestHost
+{
+    public static class TestServerExtensions
+    {
+        public static GraphQLHttpClient CreateGraphQLHttpClient(this TestServer server, GraphQLHttpClientOptions options, IGraphQLWebsocketJsonSerializer serializer)
+        {
+            var testWebSocketClient = server.CreateWebSocketClient();
+            testWebSocketClient.ConfigureRequest = r =>
+            {
+                r.Headers["Sec-WebSocket-Protocol"] = "graphql-ws";
+            };
+
+            return new GraphQLHttpClient(options, serializer, server.CreateClient(), (uri, token) => testWebSocketClient.ConnectAsync(uri, token));
+        }
+    }
+}

--- a/tests/GraphQL.Integration.Tests/GraphQL.Integration.Tests.csproj
+++ b/tests/GraphQL.Integration.Tests/GraphQL.Integration.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.3.2" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
@@ -16,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\GraphQL.Client.Serializer.Newtonsoft\GraphQL.Client.Serializer.Newtonsoft.csproj" />
     <ProjectReference Include="..\..\src\GraphQL.Client.Serializer.SystemTextJson\GraphQL.Client.Serializer.SystemTextJson.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.Client.TestHost\GraphQL.Client.TestHost.csproj" />
     <ProjectReference Include="..\..\src\GraphQL.Client\GraphQL.Client.csproj" />
     <ProjectReference Include="..\IntegrationTestServer\IntegrationTestServer.csproj" />
   </ItemGroup>

--- a/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/IntegrationServerTestFixture.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Integration.Tests.Helpers
     {
         public int Port { get; private set; }
 
-        public IWebHost Server { get; private set; }
+        public IWebHost Server { get; protected set; }
 
         public abstract IGraphQLWebsocketJsonSerializer Serializer { get; }
 
@@ -23,7 +23,7 @@ namespace GraphQL.Integration.Tests.Helpers
             Port = NetworkHelpers.GetFreeTcpPortNumber();
         }
 
-        public async Task CreateServer()
+        public virtual async Task CreateServer()
         {
             if (Server != null)
                 return;
@@ -46,21 +46,11 @@ namespace GraphQL.Integration.Tests.Helpers
         public GraphQLHttpClient GetChatClient(bool requestsViaWebsocket = false)
             => GetGraphQLClient(Common.CHAT_ENDPOINT, requestsViaWebsocket);
 
-        private GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
+        protected virtual GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
         {
             if (Serializer == null)
                 throw new InvalidOperationException("JSON serializer not configured");
             return WebHostHelpers.GetGraphQLClient(Port, endpoint, requestsViaWebsocket, Serializer);
         }
-    }
-
-    public class NewtonsoftIntegrationServerTestFixture : IntegrationServerTestFixture
-    {
-        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new NewtonsoftJsonSerializer();
-    }
-
-    public class SystemTextJsonIntegrationServerTestFixture : IntegrationServerTestFixture
-    {
-        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new SystemTextJsonSerializer();
     }
 }

--- a/tests/GraphQL.Integration.Tests/Helpers/NewtonsoftIntegrationServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/NewtonsoftIntegrationServerTestFixture.cs
@@ -1,0 +1,10 @@
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Serializer.Newtonsoft;
+
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public class NewtonsoftIntegrationServerTestFixture : IntegrationServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new NewtonsoftJsonSerializer();
+    }
+}

--- a/tests/GraphQL.Integration.Tests/Helpers/SystemTextJsonIntegrationServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/SystemTextJsonIntegrationServerTestFixture.cs
@@ -1,0 +1,10 @@
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Serializer.SystemTextJson;
+
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public class SystemTextJsonIntegrationServerTestFixture : IntegrationServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new SystemTextJsonSerializer();
+    }
+}

--- a/tests/GraphQL.Integration.Tests/Helpers/TestServerTestFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/TestServerTestFixture.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GraphQL.Client.Http;
+using GraphQL.Client.TestHost;
+using IntegrationTestServer;
+using MartinCostello.Logging.XUnit;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public abstract class TestServerTestFixture : IntegrationServerTestFixture
+    {
+        private TestServer _testServer;
+        public ITestOutputHelper Output { get; set; }
+        public override async Task CreateServer()
+        {
+            var host =
+                new WebHostBuilder()
+                    .UseStartup<Startup>()
+                    .ConfigureLogging((ctx, logging) =>
+                    {
+                        logging.AddProvider(new XUnitLoggerProvider(Output, new XUnitLoggerOptions()));
+                        logging.SetMinimumLevel(LogLevel.Trace);
+                    });
+
+            _testServer = new TestServer(host);
+            Server = _testServer.Host;
+            await _testServer.Host.StartAsync();
+        }
+
+        protected override GraphQLHttpClient GetGraphQLClient(string endpoint, bool requestsViaWebsocket = false)
+        {
+            if (Serializer == null)
+                throw new InvalidOperationException("JSON serializer not configured");
+
+            return _testServer.CreateGraphQLHttpClient(new GraphQLHttpClientOptions
+                {
+                    EndPoint = new Uri($"http://localhost:{Port}{endpoint}"),
+                    UseWebSocketForQueriesAndMutations = requestsViaWebsocket
+                },
+                Serializer);
+        }
+    }
+}

--- a/tests/GraphQL.Integration.Tests/Helpers/TestServerTestNewtonsoftFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/TestServerTestNewtonsoftFixture.cs
@@ -1,0 +1,10 @@
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Serializer.Newtonsoft;
+
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public class TestServerTestNewtonsoftFixture : TestServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new NewtonsoftJsonSerializer();
+    }
+}

--- a/tests/GraphQL.Integration.Tests/Helpers/TestServerTestSystemTextFixture.cs
+++ b/tests/GraphQL.Integration.Tests/Helpers/TestServerTestSystemTextFixture.cs
@@ -1,0 +1,10 @@
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Serializer.SystemTextJson;
+
+namespace GraphQL.Integration.Tests.Helpers
+{
+    public class TestServerTestSystemTextFixture : TestServerTestFixture
+    {
+        public override IGraphQLWebsocketJsonSerializer Serializer { get; } = new SystemTextJsonSerializer();
+    }
+}

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Base.cs
@@ -1,16 +1,12 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using FluentAssertions.Extensions;
 using GraphQL.Client.Abstractions;
-using GraphQL.Client.Abstractions.Websocket;
 using GraphQL.Client.Http;
 using GraphQL.Client.Tests.Common.Chat;
 using GraphQL.Client.Tests.Common.Chat.Schema;
@@ -79,7 +75,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             var response = await ChatClient.AddMessageAsync(message);
             response.Data.AddMessage.Content.Should().Be(message);
         }
-        
+
         [Fact]
         public async void CanUseDedicatedWebSocketEndpoint()
         {
@@ -91,7 +87,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             var response = await ChatClient.AddMessageAsync(message);
             response.Data.AddMessage.Content.Should().Be(message);
         }
-        
+
         [Fact]
         public async void CanUseDedicatedWebSocketEndpointWithoutHttpEndpoint()
         {
@@ -158,7 +154,7 @@ namespace GraphQL.Integration.Tests.WebsocketTests
 			  }
 			}";
 
-        private readonly GraphQLRequest _subscriptionRequest = new GraphQLRequest(SUBSCRIPTION_QUERY);
+        protected readonly GraphQLRequest _subscriptionRequest = new GraphQLRequest(SUBSCRIPTION_QUERY);
 
 
         [Fact]
@@ -354,79 +350,6 @@ namespace GraphQL.Integration.Tests.WebsocketTests
             await messagesMonitor.Should().CompleteAsync();
         }
 
-
-        [Fact]
-        public async void CanHandleConnectionTimeout()
-        {
-            var errorMonitor = new CallbackMonitor<Exception>();
-            var reconnectBlocker = new ManualResetEventSlim(false);
-
-            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
-            // configure back-off strategy to allow it to be controlled from within the unit test
-            ChatClient.Options.BackOffStrategy = i =>
-            {
-                Debug.WriteLine("back-off strategy: waiting on reconnect blocker");
-                reconnectBlocker.Wait();
-                Debug.WriteLine("back-off strategy: reconnecting...");
-                return TimeSpan.Zero;
-            };
-
-            var websocketStates = new ConcurrentQueue<GraphQLWebsocketConnectionState>();
-
-            using (ChatClient.WebsocketConnectionState.Subscribe(websocketStates.Enqueue))
-            {
-                websocketStates.Should().ContainSingle(state => state == GraphQLWebsocketConnectionState.Disconnected);
-
-                Debug.WriteLine($"Test method thread id: {Thread.CurrentThread.ManagedThreadId}");
-                Debug.WriteLine("creating subscription stream");
-                var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest, errorMonitor.Invoke);
-
-                Debug.WriteLine("subscribing...");
-                var observer = observable.Observe();
-                callbackMonitor.Should().HaveBeenInvokedWithPayload();
-
-                websocketStates.Should().ContainInOrder(
-                    GraphQLWebsocketConnectionState.Disconnected,
-                    GraphQLWebsocketConnectionState.Connecting,
-                    GraphQLWebsocketConnectionState.Connected);
-                // clear the collection so the next tests on the collection work as expected
-                websocketStates.Clear();
-
-                await observer.Should().PushAsync(1);
-                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
-
-                const string message1 = "Hello World";
-                var response = await ChatClient.AddMessageAsync(message1);
-                response.Data.AddMessage.Content.Should().Be(message1);
-                await observer.Should().PushAsync(2);
-                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(message1);
-
-                Debug.WriteLine("stopping web host...");
-                await Fixture.ShutdownServer();
-                Debug.WriteLine("web host stopped");
-
-                errorMonitor.Should().HaveBeenInvokedWithPayload(10.Seconds())
-                    .Which.Should().BeOfType<WebSocketException>();
-                websocketStates.Should().Contain(GraphQLWebsocketConnectionState.Disconnected);
-
-                Debug.WriteLine("restarting web host...");
-                await InitializeAsync();
-                Debug.WriteLine("web host started");
-                reconnectBlocker.Set();
-                callbackMonitor.Should().HaveBeenInvokedWithPayload(3.Seconds());
-                await observer.Should().PushAsync(3);
-                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
-
-                websocketStates.Should().ContainInOrder(
-                    GraphQLWebsocketConnectionState.Disconnected,
-                    GraphQLWebsocketConnectionState.Connecting,
-                    GraphQLWebsocketConnectionState.Connected);
-
-                // disposing the client should complete the subscription
-                ChatClient.Dispose();
-                await observer.Should().CompleteAsync(5.Seconds());
-            }
-        }
 
         [Fact]
         public async void CanHandleSubscriptionError()

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/BaseWithTimeout.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/BaseWithTimeout.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Threading;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using GraphQL.Client.Abstractions.Websocket;
+using GraphQL.Client.Tests.Common.Chat;
+using GraphQL.Client.Tests.Common.FluentAssertions.Reactive;
+using GraphQL.Client.Tests.Common.Helpers;
+using GraphQL.Integration.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public abstract class BaseWithTimeout:Base
+    {
+
+        protected BaseWithTimeout(ITestOutputHelper output, IntegrationServerTestFixture fixture) : base(output, fixture)
+        {
+        }
+        
+        [Fact]
+        public async void CanHandleConnectionTimeout()
+        {
+            var errorMonitor = new CallbackMonitor<Exception>();
+            var reconnectBlocker = new ManualResetEventSlim(false);
+
+            var callbackMonitor = ChatClient.ConfigureMonitorForOnWebsocketConnected();
+            // configure back-off strategy to allow it to be controlled from within the unit test
+            ChatClient.Options.BackOffStrategy = i =>
+            {
+                Debug.WriteLine("back-off strategy: waiting on reconnect blocker");
+                reconnectBlocker.Wait();
+                Debug.WriteLine("back-off strategy: reconnecting...");
+                return TimeSpan.Zero;
+            };
+
+            var websocketStates = new ConcurrentQueue<GraphQLWebsocketConnectionState>();
+
+            using (ChatClient.WebsocketConnectionState.Subscribe(websocketStates.Enqueue))
+            {
+                websocketStates.Should().ContainSingle(state => state == GraphQLWebsocketConnectionState.Disconnected);
+
+                Debug.WriteLine($"Test method thread id: {Thread.CurrentThread.ManagedThreadId}");
+                Debug.WriteLine("creating subscription stream");
+                var observable = ChatClient.CreateSubscriptionStream<MessageAddedSubscriptionResult>(_subscriptionRequest, errorMonitor.Invoke);
+
+                Debug.WriteLine("subscribing...");
+                var observer = observable.Observe();
+                callbackMonitor.Should().HaveBeenInvokedWithPayload();
+
+                websocketStates.Should().ContainInOrder(
+                    GraphQLWebsocketConnectionState.Disconnected,
+                    GraphQLWebsocketConnectionState.Connecting,
+                    GraphQLWebsocketConnectionState.Connected);
+                // clear the collection so the next tests on the collection work as expected
+                websocketStates.Clear();
+
+                await observer.Should().PushAsync(1);
+                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+
+                const string message1 = "Hello World";
+                var response = await ChatClient.AddMessageAsync(message1);
+                response.Data.AddMessage.Content.Should().Be(message1);
+                await observer.Should().PushAsync(2);
+                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(message1);
+
+                Debug.WriteLine("stopping web host...");
+                await Fixture.ShutdownServer();
+                Debug.WriteLine("web host stopped");
+
+                errorMonitor.Should().HaveBeenInvokedWithPayload(100.Seconds())
+                    .Which.Should().BeOfType<WebSocketException>();
+                websocketStates.Should().Contain(GraphQLWebsocketConnectionState.Disconnected);
+
+                Debug.WriteLine("restarting web host...");
+                await InitializeAsync();
+                Debug.WriteLine("web host started");
+                reconnectBlocker.Set();
+                callbackMonitor.Should().HaveBeenInvokedWithPayload(3.Seconds());
+                await observer.Should().PushAsync(3);
+                observer.RecordedMessages.Last().Data.MessageAdded.Content.Should().Be(InitialMessage.Content);
+
+                websocketStates.Should().ContainInOrder(
+                    GraphQLWebsocketConnectionState.Disconnected,
+                    GraphQLWebsocketConnectionState.Connecting,
+                    GraphQLWebsocketConnectionState.Connected);
+
+                // disposing the client should complete the subscription
+                ChatClient.Dispose();
+                await observer.Should().CompleteAsync(5.Seconds());
+            }
+        }
+    }
+}

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/Newtonsoft.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace GraphQL.Integration.Tests.WebsocketTests
 {
-    public class Newtonsoft : Base, IClassFixture<NewtonsoftIntegrationServerTestFixture>
+    public class Newtonsoft : BaseWithTimeout, IClassFixture<NewtonsoftIntegrationServerTestFixture>
     {
         public Newtonsoft(ITestOutputHelper output, NewtonsoftIntegrationServerTestFixture fixture) : base(output, fixture)
         {

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/SystemTextJson.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/SystemTextJson.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace GraphQL.Integration.Tests.WebsocketTests
 {
-    public class SystemTextJson : Base, IClassFixture<SystemTextJsonIntegrationServerTestFixture>
+    public class SystemTextJson : BaseWithTimeout, IClassFixture<SystemTextJsonIntegrationServerTestFixture>
     {
         public SystemTextJson(ITestOutputHelper output, SystemTextJsonIntegrationServerTestFixture fixture) : base(output, fixture)
         {

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/TestServerNewtonsoft.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/TestServerNewtonsoft.cs
@@ -1,0 +1,14 @@
+using GraphQL.Integration.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public class TestServerNewtonsoft : Base, IClassFixture<TestServerTestNewtonsoftFixture>
+    {
+        public TestServerNewtonsoft(ITestOutputHelper output, TestServerTestNewtonsoftFixture fixture) : base(output, fixture)
+        {
+            fixture.Output = output;
+        }
+    }
+}

--- a/tests/GraphQL.Integration.Tests/WebsocketTests/TestServerSystemTextJson.cs
+++ b/tests/GraphQL.Integration.Tests/WebsocketTests/TestServerSystemTextJson.cs
@@ -1,0 +1,14 @@
+using GraphQL.Integration.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GraphQL.Integration.Tests.WebsocketTests
+{
+    public class TestServerSystemTextJson : Base, IClassFixture<TestServerTestSystemTextFixture>
+    {
+        public TestServerSystemTextJson(ITestOutputHelper output, TestServerTestSystemTextFixture fixture) : base(output, fixture)
+        {
+            fixture.Output = output;
+        }
+    }
+}


### PR DESCRIPTION
This PR makes GraphQLHttpClient usable with TestServer.  

Usage: 
```
  TestServer testServer; //needs initiazation
  GraphQLHttpClientOptions options; //needs initiazation
  IGraphQLWebsocketJsonSerializer serializer;  //needs initiazation

  var graphQLHttpClient = testServer.CreateGraphQLHttpClient(options,serializer);
```

Implementation: 
 GraphQLHttpClient and GraphQLHttpWebSocket have a new internal constructor with a new factory parameter for connected WebSocket creation. 

```
Func<Uri, CancellationToken,Task<WebSocket>> connectedWebSocketFactory
```
 This parameter is used to provide TestWebSocket instance from TestServer. 
 There is a new project GraphQL.Client.TestHost with the extensions method to configure this factory for a given TestServer.

Discussion items: 

1. Need to check if net461 build is ok, as I checked it only with Mono under MacOS, would be nice to check with full .Net. 
2. There is `CanHandleConnectionTimeout` integration test that I could not make work for TestServer.  Seems like TestServer does not drop WebSocket connection on dispose. I could be wrong. Any help or suggestions are welcome. As a shortcut, I moved this test out of scope for TestServer
3. Way to inject WebSocket into GraphQLHttpClient. Now it is dictated by TestServer's WebSocketClient, and, maybe, there is a better way other than  GraphQLHttpClient internal constructor requiring complex factory setup and separate project usage. 
4. Tests stability, as mentioned in #161. I can see the same behavior for TestServer and think it is caused by synchronization inside tests themselves. It is not targeted here, but we can check it by running a dedicated server for each test. 
