### PR TITLE
Move IDisposable to implementation

### DIFF
--- a/src/GraphQL.Client.Abstractions/IGraphQLClient.cs
+++ b/src/GraphQL.Client.Abstractions/IGraphQLClient.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Client.Abstractions
 {
-    public interface IGraphQLClient : IDisposable
+    public interface IGraphQLClient
     {
         Task<GraphQLResponse<TResponse>> SendQueryAsync<TResponse>(GraphQLRequest request, CancellationToken cancellationToken = default);
 
@@ -14,7 +14,7 @@ namespace GraphQL.Client.Abstractions
         /// <summary>
         /// Creates a subscription to a GraphQL server. The connection is not established until the first actual subscription is made.<br/>
         /// All subscriptions made to this stream share the same hot observable.<br/>
-        /// The stream must be recreated completely after an error has occured within its logic (i.e. a <see cref="WebSocketException"/>)
+        /// The stream must be recreated completely after an error has occurred within its logic (i.e. a <see cref="WebSocketException"/>)
         /// </summary>
         /// <param name="request">the GraphQL request for this subscription</param>
         /// <returns>an observable stream for the specified subscription</returns>

--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -12,7 +12,7 @@ using GraphQL.Client.Http.Websocket;
 
 namespace GraphQL.Client.Http
 {
-    public class GraphQLHttpClient : IGraphQLClient
+    public class GraphQLHttpClient : IGraphQLClient, IDisposable
     {
         private readonly Lazy<GraphQLHttpWebSocket> _lazyHttpWebSocket;
         private GraphQLHttpWebSocket GraphQlHttpWebSocket => _lazyHttpWebSocket.Value;


### PR DESCRIPTION
Normally the caller should not interact with `IDisposable` provided via `IGraphQLClient` interface.