### PR TITLE
Allow non-200 HTTP status codes

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpClient.cs
+++ b/src/GraphQL.Client/GraphQLHttpClient.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Client.Http
         private readonly Lazy<GraphQLHttpWebSocket> _lazyHttpWebSocket;
         private GraphQLHttpWebSocket GraphQlHttpWebSocket => _lazyHttpWebSocket.Value;
 
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         private readonly bool _disposeHttpClient = false;
 
@@ -42,14 +42,17 @@ namespace GraphQL.Client.Http
 
         #region Constructors
 
-        public GraphQLHttpClient(string endPoint, IGraphQLWebsocketJsonSerializer serializer) : this(new Uri(endPoint), serializer) { }
+        public GraphQLHttpClient(string endPoint, IGraphQLWebsocketJsonSerializer serializer)
+            : this(new Uri(endPoint), serializer) { }
 
-        public GraphQLHttpClient(Uri endPoint, IGraphQLWebsocketJsonSerializer serializer) : this(o => o.EndPoint = endPoint, serializer) { }
+        public GraphQLHttpClient(Uri endPoint, IGraphQLWebsocketJsonSerializer serializer)
+            : this(o => o.EndPoint = endPoint, serializer) { }
 
-        public GraphQLHttpClient(Action<GraphQLHttpClientOptions> configure, IGraphQLWebsocketJsonSerializer serializer) : this(configure.New(), serializer) { }
+        public GraphQLHttpClient(Action<GraphQLHttpClientOptions> configure, IGraphQLWebsocketJsonSerializer serializer)
+            : this(configure.New(), serializer) { }
 
-        public GraphQLHttpClient(GraphQLHttpClientOptions options, IGraphQLWebsocketJsonSerializer serializer) : this(
-            options, serializer, new HttpClient(options.HttpMessageHandler))
+        public GraphQLHttpClient(GraphQLHttpClientOptions options, IGraphQLWebsocketJsonSerializer serializer)
+            : this(options, serializer, new HttpClient(options.HttpMessageHandler))
         {
             // set this flag to dispose the internally created HttpClient when GraphQLHttpClient gets disposed
             _disposeHttpClient = true;
@@ -120,7 +123,7 @@ namespace GraphQL.Client.Http
 
             var contentStream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            if (httpResponseMessage.IsSuccessStatusCode)
+            if (Options.IsValidResponseToDeserialize(httpResponseMessage))
             {
                 var graphQLResponse = await JsonSerializer.DeserializeFromUtf8StreamAsync<TResponse>(contentStream, cancellationToken).ConfigureAwait(false);
                 return graphQLResponse.ToGraphQLHttpResponse(httpResponseMessage.Headers, httpResponseMessage.StatusCode);
@@ -167,7 +170,7 @@ namespace GraphQL.Client.Http
         }
 
         private volatile bool _disposed;
-        private readonly object _disposeLocker = new object();
+        private readonly object _disposeLocker = new();
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -52,7 +52,7 @@ namespace GraphQL.Client.Http
         /// <summary>
         /// Delegate to determine if GraphQL response may be properly deserialized into <see cref="GraphQLResponse{T}"/>.
         /// </summary>
-        public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = r => r.IsSuccessStatusCode;
+        public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = r => r.IsSuccessStatusCode || r.StatusCode == HttpStatusCode.BadRequest;
 
         /// <summary>
         /// This callback is called after successfully establishing a websocket connection but before any regular request is made.

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Client.Http
         /// <summary>
         /// The GraphQL EndPoint to be used for websocket connections
         /// </summary>
-        public Uri? WebSocketEndPoint { get; set; } = null;
+        public Uri? WebSocketEndPoint { get; set; }
 
         /// <summary>
         /// The <see cref="System.Net.Http.HttpMessageHandler"/> that is going to be used
@@ -50,12 +50,17 @@ namespace GraphQL.Client.Http
             Task.FromResult(request is GraphQLHttpRequest graphQLHttpRequest ? graphQLHttpRequest : new GraphQLHttpRequest(request));
 
         /// <summary>
-        /// This callback is called after successfully establishing a websocket connection but before any regular request is made. 
+        /// Delegate to determine if GraphQL response may be properly deserialized into <see cref="GraphQLResponse{T}"/>.
+        /// </summary>
+        public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = r => r.IsSuccessStatusCode;
+
+        /// <summary>
+        /// This callback is called after successfully establishing a websocket connection but before any regular request is made.
         /// </summary>
         public Func<GraphQLHttpClient, Task> OnWebsocketConnected { get; set; } = client => Task.CompletedTask;
 
         /// <summary>
-        /// Configure additional websocket options (i.e. headers). This will not be invoked on Windows 7 when targeting .NET Framework 4.x. 
+        /// Configure additional websocket options (i.e. headers). This will not be invoked on Windows 7 when targeting .NET Framework 4.x.
         /// </summary>
         public Action<ClientWebSocketOptions> ConfigureWebsocketOptions { get; set; } = options => { };
 

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.WebSockets;
 


### PR DESCRIPTION
See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes . Spec allow to return 400 i ncase of validation errors. GraphQL.NET / server support it.