### PR TITLE
Fix NullReferenceException from GraphQLHttpClientOptions.IsValidResponseToDeserialize

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -57,7 +57,7 @@ public class GraphQLHttpClientOptions
     /// </summary>
     public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = r =>
         // Why not application/json? See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#processing-the-response
-        r.IsSuccessStatusCode || r.StatusCode == HttpStatusCode.BadRequest || r.Content.Headers.ContentType.MediaType == "application/graphql+json";
+        r.IsSuccessStatusCode || r.StatusCode == HttpStatusCode.BadRequest || r.Content.Headers.ContentType?.MediaType == "application/graphql+json";
 
     /// <summary>
     /// This callback is called after successfully establishing a websocket connection but before any regular request is made.


### PR DESCRIPTION
Avoid *NullReferenceException* when `Headers.ContentType` is `null`