### PR TITLE
Improve default IsValidResponseToDeserialize implementation

### DIFF
--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -63,7 +63,7 @@ public class GraphQLHttpClientOptions
     /// </summary>
     public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = DefaultIsValidResponseToDeserialize;
 
-    internal static IReadOnlyCollection<string> AcceptedResponseContentTypes { get; } = new[] { "application/graphql+json", "application/json", "application/graphql-response+json" };
+    private static IReadOnlyCollection<string> AcceptedResponseContentTypes { get; } = new[] { "application/graphql+json", "application/json", "application/graphql-response+json" };
 
     private static bool DefaultIsValidResponseToDeserialize(HttpResponseMessage r)
     {

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -67,7 +67,6 @@ public class GraphQLHttpClientOptions
 
     private static bool DefaultIsValidResponseToDeserialize(HttpResponseMessage r)
     {
-        // Why not application/json? See https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#processing-the-response
         if (r.Content.Headers.ContentType?.MediaType != null && !AcceptedResponseContentTypes.Contains(r.Content.Headers.ContentType.MediaType))
             return false;
 

--- a/src/GraphQL.Client/GraphQLHttpClientOptions.cs
+++ b/src/GraphQL.Client/GraphQLHttpClientOptions.cs
@@ -63,11 +63,11 @@ public class GraphQLHttpClientOptions
     /// </summary>
     public Func<HttpResponseMessage, bool> IsValidResponseToDeserialize { get; set; } = DefaultIsValidResponseToDeserialize;
 
-    private static IReadOnlyCollection<string> AcceptedResponseContentTypes { get; } = new[] { "application/graphql+json", "application/json", "application/graphql-response+json" };
+    private static readonly IReadOnlyCollection<string> _acceptedResponseContentTypes = new[] { "application/graphql+json", "application/json", "application/graphql-response+json" };
 
     private static bool DefaultIsValidResponseToDeserialize(HttpResponseMessage r)
     {
-        if (r.Content.Headers.ContentType?.MediaType != null && !AcceptedResponseContentTypes.Contains(r.Content.Headers.ContentType.MediaType))
+        if (r.Content.Headers.ContentType?.MediaType != null && !_acceptedResponseContentTypes.Contains(r.Content.Headers.ContentType.MediaType))
             return false;
 
         return r.IsSuccessStatusCode || r.StatusCode == HttpStatusCode.BadRequest;

--- a/tests/GraphQL.Client.Serializer.Tests/DefaultValidationTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/DefaultValidationTest.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using GraphQL.Client.Http;
+
+using Xunit;
+
+namespace GraphQL.Client.Serializer.Tests;
+
+public class DefaultValidationTest
+{
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK, "application/json", true)]
+    [InlineData(HttpStatusCode.OK, "application/graphql-response+json", true)]
+    [InlineData(HttpStatusCode.BadRequest, "application/json", true)]
+    [InlineData(HttpStatusCode.BadRequest, "text/html", false)]
+    [InlineData(HttpStatusCode.OK, "text/html", false)]
+    [InlineData(HttpStatusCode.Forbidden, "text/html", false)]
+    [InlineData(HttpStatusCode.Forbidden, "application/json", false)]
+    public void IsValidResponse_OkJson_True(HttpStatusCode statusCode, string mediaType, bool expectedResult)
+    {
+        var response = new HttpResponseMessage(statusCode);
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
+
+        bool result = new GraphQLHttpClientOptions().IsValidResponseToDeserialize(response);
+
+        result.Should().Be(expectedResult);
+    }
+}

--- a/tests/GraphQL.Client.Serializer.Tests/DefaultValidationTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/DefaultValidationTest.cs
@@ -2,14 +2,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using FluentAssertions;
 using GraphQL.Client.Http;
-
 using Xunit;
 
 namespace GraphQL.Client.Serializer.Tests;
 
 public class DefaultValidationTest
 {
-
     [Theory]
     [InlineData(HttpStatusCode.OK, "application/json", true)]
     [InlineData(HttpStatusCode.OK, "application/graphql-response+json", true)]
@@ -23,8 +21,8 @@ public class DefaultValidationTest
         var response = new HttpResponseMessage(statusCode);
         response.Content.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
-        bool result = new GraphQLHttpClientOptions().IsValidResponseToDeserialize(response);
+        bool isValid = new GraphQLHttpClientOptions().IsValidResponseToDeserialize(response);
 
-        result.Should().Be(expectedResult);
+        isValid.Should().Be(expectedResult);
     }
 }


### PR DESCRIPTION
As mentioned in issue https://github.com/graphql-dotnet/graphql-client/issues/554 the default implementation of `IsValidResponseToDeserialize` currently does not verify if the response actually can be deserialized, regardless of its name.

As it's a logical OR it completely ignores the ContentType as long s the status matches Ok or BadRequest. At the same time it's possible that a server or any other component even before reaching the server returns one of those statuses in incorrect ContentType. Such behavior ends up with an ugly runtime exception, while it can be easily handled.

I also made this method more readable and debuggable. It's discussable if AcceptedResponseContentTypes  should be editable and exposed.