### PR TITLE
Fix ImmutableConverter.cs

### DIFF
--- a/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/BaseSerializerTest.cs
@@ -190,4 +190,29 @@ public abstract class BaseSerializerTest
 
         action.Should().NotThrow();
     }
+
+    [Fact]
+    public async Task CanDeserializeObjectWithBothConstructorAndProperties()
+    {
+        // Arrange
+        const string jsonString = @"{ ""data"": { ""property1"": ""value1"", ""property2"": ""value2"" } }";
+        var contentStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(jsonString));
+
+        // Act
+        var result = await ClientSerializer.DeserializeFromUtf8StreamAsync<WithConstructorAndProperties>(contentStream, default).ConfigureAwait(false);
+
+        // Assert
+        result.Data.Property1.Should().Be("value1");
+        result.Data.Property2.Should().Be("value2");
+    }
+
+    private class WithConstructorAndProperties
+    {
+        public WithConstructorAndProperties(string property2)
+        {
+            Property2 = property2;
+        }
+        public string? Property1 { get; set; }
+        public string Property2 { get; }
+    }
 }

--- a/tests/GraphQL.Client.Serializer.Tests/SystemTextJsonSerializerTests.cs
+++ b/tests/GraphQL.Client.Serializer.Tests/SystemTextJsonSerializerTests.cs
@@ -1,9 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using FluentAssertions;
 using GraphQL.Client.Serializer.SystemTextJson;
 using GraphQL.Execution;
-using Xunit;
 
 namespace GraphQL.Client.Serializer.Tests;
 
@@ -14,32 +12,6 @@ public class SystemTextJsonSerializerTests : BaseSerializerTest
             new SystemTextJsonSerializer(),
             new GraphQL.SystemTextJson.GraphQLSerializer(new ErrorInfoProvider(opt => opt.ExposeData = true)))
     {
-    }
-
-    [Fact]
-    public async Task DeserializingObjectWithBothConstructorAndProperties()
-    {
-        // Arrange
-        const string jsonString = @"{ ""data"": { ""optionalTestProperty"": ""optional"", ""requiredTestProperty"": ""required"" } }";
-        var graphQlSerializer = new SystemTextJsonSerializer();
-        var contentStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(jsonString));
-        
-        // Act
-        var result = await graphQlSerializer.DeserializeFromUtf8StreamAsync<SerializerTestClass>(contentStream, default).ConfigureAwait(false);
-        
-        // Assert
-        result.Data.RequiredTestProperty.Should().Be("required");
-        result.Data.OptionalTestProperty.Should().Be("optional");
-    }
-
-    private class SerializerTestClass
-    {
-        public SerializerTestClass(string requiredTestProperty)
-        {
-            RequiredTestProperty = requiredTestProperty;
-        }
-        public string? OptionalTestProperty { get; set; }
-        public string RequiredTestProperty { get; }
     }
 }
 


### PR DESCRIPTION
Swap properties and parameters in applicability check of ImmutableConverter. This prevents properties from being lost when they are not all represented in the contructor as parameters.

Fixes #571 