### PR TITLE
Removed reference to GraphQL.Client.Serializer.Newtonsoft in GraphQL.Client.LocalExecution

### DIFF
--- a/src/GraphQL.Client.LocalExecution/GraphQL.Client.LocalExecution.csproj
+++ b/src/GraphQL.Client.LocalExecution/GraphQL.Client.LocalExecution.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GraphQL.Client.Abstractions\GraphQL.Client.Abstractions.csproj" />
-    <ProjectReference Include="..\GraphQL.Client.Serializer.Newtonsoft\GraphQL.Client.Serializer.Newtonsoft.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #632

Noticed that this might be something unused, let me know if it's there for some purpose