### PR TITLE
Waiting when disposing till the stop message was sent

### DIFF
--- a/src/GraphQL.Client/Websocket/GraphQLTransportWSProtocolHandler.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLTransportWSProtocolHandler.cs
@@ -116,7 +116,7 @@ internal class GraphQLTransportWSProtocolHandler : IWebsocketProtocolHandler
 
             var disposable = new CompositeDisposable(
                 observable.Subscribe(observer),
-                Disposable.Create(async () =>
+                Disposable.Create(() =>
                 {
                     Debug.WriteLine($"disposing subscription {startRequest.Id}, websocket state is '{_webSocketHandler.WebSocketState}'");
                     // only try to send close request on open websocket
@@ -126,7 +126,7 @@ internal class GraphQLTransportWSProtocolHandler : IWebsocketProtocolHandler
                     try
                     {
                         Debug.WriteLine($"sending stop message on subscription {startRequest.Id}");
-                        await _queueWebSocketRequest(stopRequest).ConfigureAwait(false);
+                        _queueWebSocketRequest(stopRequest).GetAwaiter().GetResult();
                     }
                     // do not break on disposing
                     catch (OperationCanceledException) { }

--- a/src/GraphQL.Client/Websocket/GraphQLWSProtocolHandler.cs
+++ b/src/GraphQL.Client/Websocket/GraphQLWSProtocolHandler.cs
@@ -101,7 +101,7 @@ internal class GraphQLWSProtocolHandler : IWebsocketProtocolHandler
 
             var disposable = new CompositeDisposable(
                 observable.Subscribe(observer),
-                Disposable.Create(async () =>
+                Disposable.Create(() =>
                 {
                     Debug.WriteLine($"disposing subscription {startRequest.Id}, websocket state is '{_webSocketHandler.WebSocketState}'");
                     // only try to send close request on open websocket
@@ -111,7 +111,7 @@ internal class GraphQLWSProtocolHandler : IWebsocketProtocolHandler
                     try
                     {
                         Debug.WriteLine($"sending stop message on subscription {startRequest.Id}");
-                        await _queueWebSocketRequest(stopRequest).ConfigureAwait(false);
+                        _queueWebSocketRequest(stopRequest).GetAwaiter().GetResult();
                     }
                     // do not break on disposing
                     catch (OperationCanceledException) { }


### PR DESCRIPTION
If the subscription gets disposed and the _queueWebSocketRequest fails with an exception, there is the possibility to crash the application.

To be able to catch this exception, it would be helpful to not use async/await because async is not supported by Disposable.Create

fix #326 